### PR TITLE
Fix LoginTest race condition with parallel execution

### DIFF
--- a/src/test/java/com/automation/tests/LoginTest.java
+++ b/src/test/java/com/automation/tests/LoginTest.java
@@ -10,29 +10,29 @@ import com.automation.utils.ConfigReader;
 
 public class LoginTest extends BaseTest {
 
-    private LoginPage loginPage;
+    private static ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
 
     @BeforeMethod
     public void setUpPage() {
         getDriver().get(ConfigReader.get("BASE_URL"));
-        loginPage = new LoginPage(getDriver());
+        loginPage.set(new LoginPage(getDriver()));
     }
 
     @Test
     public void successfulLoginTest() {
-        loginPage.login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("PASSWORD"));
+        loginPage.get().login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("PASSWORD"));
         assertThat(getDriver().getCurrentUrl()).isEqualTo(ConfigReader.get("BASE_URL") + ConfigReader.get("INVENTORY_PATH"));
     }
 
     @Test
     public void lockedOutUserTest() {
-        loginPage.login(ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"));
-        assertThat(loginPage.getErrorMessage()).contains("Sorry, this user has been locked out");
+        loginPage.get().login(ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"));
+        assertThat(loginPage.get().getErrorMessage()).contains("Sorry, this user has been locked out");
     }
 
     @Test
     public void invalidPasswordTest() {
-        loginPage.login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"));
-        assertThat(loginPage.getErrorMessage()).contains("Username and password do not match any user in this service");
+        loginPage.get().login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"));
+        assertThat(loginPage.get().getErrorMessage()).contains("Username and password do not match any user in this service");
     }
  }


### PR DESCRIPTION
## Summary
Wraps `loginPage` in `ThreadLocal<LoginPage>` to prevent race 
conditions when TestNG runs LoginTest methods in parallel.

## Problem
With `parallel="methods" thread-count="2"`, two threads could 
overwrite each other's `loginPage` reference, causing tests to 
interact with the wrong browser instance.

## Changes
- `loginPage` changed from plain instance variable to `ThreadLocal<LoginPage>`
- All test methods updated to use `loginPage.get()`
- `setUpPage()` updated to use `loginPage.set()`

## Test Results
Tests run: 6, Failures: 0
- 3 TestNG tests passing
- 3 Cucumber scenarios passing

Closes #21