### PR TITLE
Add testng dataprovider driven tests

### DIFF
--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -63,7 +63,7 @@ public class BaseTest {
         driver.set(webDriver);
     }
 
-    @AfterMethod
+    @AfterMethod(alwaysRun=true)
     public void tearDown() {
         if (driver.get() != null) {
             driver.get().quit();

--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -17,7 +17,7 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 
 public class BaseTest {
 
-    private static ThreadLocal<WebDriver> driver = new ThreadLocal<>();
+    private static final ThreadLocal<WebDriver> driver = new ThreadLocal<>();
 
     public WebDriver getDriver() {
         return driver.get();

--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -56,7 +56,6 @@ public class BaseTest {
                 webDriver = new FirefoxDriver(firefoxOptions);
                 break;
 
-
         }
 
         webDriver.manage().window().maximize();
@@ -65,8 +64,12 @@ public class BaseTest {
 
     @AfterMethod(alwaysRun=true)
     public void tearDown() {
-        if (driver.get() != null) {
-            driver.get().quit();
+        WebDriver currentDriver = driver.get();
+        try {
+            if (currentDriver != null) {
+                currentDriver.quit();
+            }
+        } finally {
             driver.remove();
         }
     }

--- a/src/test/java/com/automation/testdata/LoginScenario.java
+++ b/src/test/java/com/automation/testdata/LoginScenario.java
@@ -1,0 +1,9 @@
+package com.automation.testdata;
+
+public record LoginScenario(String name, String username, String password, String expectedError) {
+    @Override
+    public String toString() {
+        return name;
+    }
+}
+

--- a/src/test/java/com/automation/tests/LoginTest.java
+++ b/src/test/java/com/automation/tests/LoginTest.java
@@ -1,6 +1,7 @@
 package com.automation.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -39,5 +40,10 @@ public class LoginTest extends BaseTest {
         {new LoginScenario("invalid password", ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"), "Username and password do not match any user in this service")}
         };
     }
+
+     @AfterMethod(alwaysRun=true)
+     public void tearDownPage()  {
+        loginPage.remove();
+     }
 
  }

--- a/src/test/java/com/automation/tests/LoginTest.java
+++ b/src/test/java/com/automation/tests/LoginTest.java
@@ -2,16 +2,18 @@ package com.automation.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.automation.base.BaseTest;
 import com.automation.pages.LoginPage;
+import com.automation.testdata.LoginScenario;
 import com.automation.utils.ConfigReader;
 
 public class LoginTest extends BaseTest {
 
     private static ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
-
+    
     @BeforeMethod
     public void setUpPage() {
         getDriver().get(ConfigReader.get("BASE_URL"));
@@ -24,15 +26,18 @@ public class LoginTest extends BaseTest {
         assertThat(getDriver().getCurrentUrl()).isEqualTo(ConfigReader.get("BASE_URL") + ConfigReader.get("INVENTORY_PATH"));
     }
 
-    @Test
-    public void lockedOutUserTest() {
-        loginPage.get().login(ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"));
-        assertThat(loginPage.get().getErrorMessage()).contains("Sorry, this user has been locked out");
+    @Test(dataProvider="failedLoginData")
+    public void failedLoginTest(LoginScenario scenario) {
+        loginPage.get().login(scenario.username(), scenario.password());
+        assertThat(loginPage.get().getErrorMessage()).contains(scenario.expectedError());
     }
 
-    @Test
-    public void invalidPasswordTest() {
-        loginPage.get().login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"));
-        assertThat(loginPage.get().getErrorMessage()).contains("Username and password do not match any user in this service");
+    @DataProvider(name = "failedLoginData")
+    public Object[][] failedLoginData() {
+        return new Object[][] {
+        {new LoginScenario("locked out user", ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"), "Sorry, this user has been locked out")},
+        {new LoginScenario("invalid password", ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"), "Username and password do not match any user in this service")}
+        };
     }
+
  }

--- a/src/test/java/com/automation/tests/LoginTest.java
+++ b/src/test/java/com/automation/tests/LoginTest.java
@@ -12,7 +12,7 @@ import com.automation.utils.ConfigReader;
 
 public class LoginTest extends BaseTest {
 
-    private static ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
+    private static final ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
     
     @BeforeMethod
     public void setUpPage() {


### PR DESCRIPTION
## Summary
Adds data-driven test coverage for failed login scenarios using a TestNG DataProvider. Replaces two duplicated test methods with a single parameterised test backed by a `LoginScenario` record, making it trivial to add new failed-login cases by adding a row of data rather than a new method.

## Changes
- Added `LoginScenario` record in new `com.automation.testdata` package
- Overrode `LoginScenario.toString()` to return only the scenario name, avoiding credential leakage in TestNG failure reports
- Added `failedLoginData` DataProvider to `LoginTest`
- Replaced `lockedOutUserTest` and `invalidPasswordTest` with parameterised `failedLoginTest`
- Marked `ThreadLocal` references in `BaseTest` and `LoginTest` as `final` to prevent accidental reassignment in parallel runs

## Testing
- `mvn test` run locally — 6 tests pass (3 TestNG including 2 DataProvider invocations, 3 Cucumber scenarios)
- TestNG report shows each DataProvider row as a separate test invocation, identified by scenario name
- Verified parallel execution still works (no shared state between threads)

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored login suite into a single parameterised test covering multiple failed-login scenarios; removed duplicate failing tests.
  * Added structured test data for login scenarios with a data provider to drive assertions.
  * Ensured per-test cleanup always runs to avoid cross-test state leakage (teardown now always executes).

* **Refactor**
  * Strengthened immutability of test infrastructure components to reduce accidental reassignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->