### PR TITLE
Centralise login error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Commits follow the Conventional Commits standard:
 |---|---|
 | `feat:` | New feature or class |
 | `fix:` | Bug fix |
+| `refactor:` | Code restructure without behaviour change |
 | `chore:` | Configuration or maintenance |
 
 From v0.2.0 onwards commits reference GitHub issue numbers e.g. `closes #4`.
@@ -78,6 +79,7 @@ Branch naming convention:
 - `feature/` — new features e.g. `feature/1-cucumber-step-definitions`
 - `fix/` — bug fixes e.g. `fix/18-login-test-coverage`
 - `chore/` — maintenance e.g. `chore/update-dependencies`
+- `refactor/` - Code restructure without behaviour change 
 
 ## Code Review
 

--- a/src/test/java/com/automation/stepdefinitions/LoginSteps.java
+++ b/src/test/java/com/automation/stepdefinitions/LoginSteps.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.automation.base.BaseTest;
 import com.automation.pages.LoginPage;
+import com.automation.testdata.LoginErrorMessages;
 import com.automation.utils.ConfigReader;
 
 import io.cucumber.java.en.Given;
@@ -48,11 +49,11 @@ public class LoginSteps {
 
     @Then("they should see a locked out error message")
     public void theyShouldSeeALockedOutMessage() {
-        assertThat(loginPage.getErrorMessage()).contains("Sorry, this user has been locked out");
+        assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.LOCKED_OUT);
     }
 
     @Then("they should see an invalid credentials error message")
     public void theyShouldSeeAnInvalidCredentialsErrorMessage() {
-        assertThat(loginPage.getErrorMessage()).contains("Username and password do not match any user in this service");
+        assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.INVALID_CREDENTIALS);
     }
 }

--- a/src/test/java/com/automation/testdata/LoginErrorMessages.java
+++ b/src/test/java/com/automation/testdata/LoginErrorMessages.java
@@ -1,0 +1,12 @@
+package com.automation.testdata;
+
+public final class LoginErrorMessages {
+
+    public static final String LOCKED_OUT = "Sorry, this user has been locked out";
+    public static final String INVALID_CREDENTIALS = "Username and password do not match any user in this service";
+
+    private LoginErrorMessages() {
+        // Utility class - prevent instantiation
+    }
+    
+}

--- a/src/test/java/com/automation/tests/LoginTest.java
+++ b/src/test/java/com/automation/tests/LoginTest.java
@@ -8,6 +8,7 @@ import org.testng.annotations.Test;
 
 import com.automation.base.BaseTest;
 import com.automation.pages.LoginPage;
+import com.automation.testdata.LoginErrorMessages;
 import com.automation.testdata.LoginScenario;
 import com.automation.utils.ConfigReader;
 
@@ -36,8 +37,8 @@ public class LoginTest extends BaseTest {
     @DataProvider(name = "failedLoginData")
     public Object[][] failedLoginData() {
         return new Object[][] {
-        {new LoginScenario("locked out user", ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"), "Sorry, this user has been locked out")},
-        {new LoginScenario("invalid password", ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"), "Username and password do not match any user in this service")}
+        {new LoginScenario("locked out user", ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"), LoginErrorMessages.LOCKED_OUT)},
+        {new LoginScenario("invalid password", ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"), LoginErrorMessages.INVALID_CREDENTIALS)}
         };
     }
 


### PR DESCRIPTION
## Summary
Centralises login error message strings into a single `LoginErrorMessages` 
constants class to eliminate duplication between `LoginSteps.java` and 
`LoginTest.java`. Removes the risk of test data drift if saucedemo's 
error text changes.

## Changes
- Added `LoginErrorMessages` utility class in `com.automation.testdata` 
  with `LOCKED_OUT` and `INVALID_CREDENTIALS` constants
- Marked as `final` with a private constructor to prevent instantiation 
  and subclassing
- Updated `LoginSteps` to reference constants in both error assertions
- Updated `LoginTest` DataProvider to reference constants in both rows
- Introduced `refactor:` prefix to the project's git convention and 
  documented it in the README

## Testing
- Baseline `mvn test` run before any changes: 6/6 passing
- Incremental `mvn test` after creating `LoginErrorMessages`: 6/6 passing
- Final `mvn test` after wiring both consumers: 6/6 passing
- Tests act as a regression safety net — behaviour is identical, only 
  the source of the strings has changed

Closes #38

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Git conventions updated to include `refactor:` commit prefix and branch naming conventions.

* **Refactor**
  * Test assertions updated to use centralised error message constants, improving code maintainability and consistency across login validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->