### PR TITLE
Spotless apply

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # Spotless mass reformat - ignore in git blame
 # Added in PR for issue #40
+31c8ecf36f3deeb25fdb37c6388a4c78e338dfb9

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Spotless mass reformat - ignore in git blame
+# Added in PR for issue #40

--- a/pom.xml
+++ b/pom.xml
@@ -1,15 +1,15 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.automation</groupId>
   <artifactId>automation-framework</artifactId>
-  <packaging>jar</packaging>
   <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
   <name>automation-framework</name>
   <url>http://maven.apache.org</url>
   <properties>
-  <maven.compiler.source>21</maven.compiler.source>
-  <maven.compiler.target>21</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
   </properties>
   <dependencies>
     <dependency>
@@ -58,7 +58,7 @@
       <version>3.25.3</version>
       <scope>test</scope>
     </dependency>
-      <dependency>
+    <dependency>
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-picocontainer</artifactId>
       <version>7.15.0</version>
@@ -66,17 +66,33 @@
     </dependency>
   </dependencies>
   <build>
-  <plugins>
-    <plugin>
-      <groupId>org.apache.maven.plugins</groupId>
-      <artifactId>maven-surefire-plugin</artifactId>
-      <version>3.2.5</version>
-      <configuration>
-        <suiteXmlFiles>
-          <suiteXmlFile>testng.xml</suiteXmlFile>
-        </suiteXmlFiles>
-      </configuration>
-    </plugin>
-  </plugins>
-</build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <suiteXmlFiles>
+            <suiteXmlFile>testng.xml</suiteXmlFile>
+          </suiteXmlFiles>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.4.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat/>
+            <removeUnusedImports/>
+            <importOrder/>
+            <formatAnnotations/>
+          </java>
+          <pom>
+            <sortPom/>
+          </pom>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -1,5 +1,7 @@
 package com.automation.base;
 
+import com.automation.utils.ConfigReader;
+import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -10,71 +12,65 @@ import org.openqa.selenium.firefox.FirefoxOptions;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
-import com.automation.utils.ConfigReader;
-
-import io.github.bonigarcia.wdm.WebDriverManager;
-
-
 public class BaseTest {
 
-    private static final ThreadLocal<WebDriver> driver = new ThreadLocal<>();
+  private static final ThreadLocal<WebDriver> driver = new ThreadLocal<>();
 
-    public WebDriver getDriver() {
-        return driver.get();
-    }
+  public WebDriver getDriver() {
+    return driver.get();
+  }
 
-    @BeforeMethod
-    public void setUp() {
-        String browser = ConfigReader.get("BROWSER").toLowerCase();
-        WebDriver webDriver;
+  @BeforeMethod
+  public void setUp() {
+    String browser = ConfigReader.get("BROWSER").toLowerCase();
+    WebDriver webDriver;
 
-        switch (browser) {
-            case "chrome":
-                WebDriverManager.chromedriver().setup();
-                ChromeOptions chromeOptions = new ChromeOptions();
-                if (isHeadless()) {
-                    chromeOptions.addArguments("--headless");
-                }
-                webDriver = new ChromeDriver(chromeOptions);
-                break;
-
-            case "edge":
-                WebDriverManager.edgedriver().setup();
-                EdgeOptions edgeOptions = new EdgeOptions();
-                if (isHeadless()) {
-                    edgeOptions.addArguments("--headless");
-                }
-                webDriver = new EdgeDriver(edgeOptions);
-                break;
-            case "firefox":
-            default:
-                WebDriverManager.firefoxdriver().setup();
-                FirefoxOptions firefoxOptions = new FirefoxOptions();
-                if (isHeadless()) {
-                    firefoxOptions.addArguments("--headless");
-                }
-                webDriver = new FirefoxDriver(firefoxOptions);
-                break;
-
+    switch (browser) {
+      case "chrome":
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions chromeOptions = new ChromeOptions();
+        if (isHeadless()) {
+          chromeOptions.addArguments("--headless");
         }
+        webDriver = new ChromeDriver(chromeOptions);
+        break;
 
-        webDriver.manage().window().maximize();
-        driver.set(webDriver);
-    }
-
-    @AfterMethod(alwaysRun=true)
-    public void tearDown() {
-        WebDriver currentDriver = driver.get();
-        try {
-            if (currentDriver != null) {
-                currentDriver.quit();
-            }
-        } finally {
-            driver.remove();
+      case "edge":
+        WebDriverManager.edgedriver().setup();
+        EdgeOptions edgeOptions = new EdgeOptions();
+        if (isHeadless()) {
+          edgeOptions.addArguments("--headless");
         }
+        webDriver = new EdgeDriver(edgeOptions);
+        break;
+      case "firefox":
+      default:
+        WebDriverManager.firefoxdriver().setup();
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        if (isHeadless()) {
+          firefoxOptions.addArguments("--headless");
+        }
+        webDriver = new FirefoxDriver(firefoxOptions);
+        break;
     }
 
-    public boolean isHeadless() {
-        return "true".equalsIgnoreCase(ConfigReader.get("HEADLESS"));
+    webDriver.manage().window().maximize();
+    driver.set(webDriver);
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDown() {
+    WebDriver currentDriver = driver.get();
+    try {
+      if (currentDriver != null) {
+        currentDriver.quit();
+      }
+    } finally {
+      driver.remove();
     }
+  }
+
+  public boolean isHeadless() {
+    return "true".equalsIgnoreCase(ConfigReader.get("HEADLESS"));
+  }
 }

--- a/src/test/java/com/automation/pages/BasePage.java
+++ b/src/test/java/com/automation/pages/BasePage.java
@@ -1,36 +1,34 @@
 package com.automation.pages;
 
 import java.time.Duration;
-
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-
 public class BasePage {
 
-    protected WebDriver driver;
-    protected WebDriverWait wait;
+  protected WebDriver driver;
+  protected WebDriverWait wait;
 
-    public BasePage(WebDriver driver) {
-        this.driver = driver;
-        this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
-    }
+  public BasePage(WebDriver driver) {
+    this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+  }
 
-    protected void click(WebElement element) {
-        wait.until(ExpectedConditions.elementToBeClickable(element));
-        element.click();
-    }
+  protected void click(WebElement element) {
+    wait.until(ExpectedConditions.elementToBeClickable(element));
+    element.click();
+  }
 
-    protected void type(WebElement element, String text) {
-        wait.until(ExpectedConditions.visibilityOf(element));
-        element.clear();
-        element.sendKeys(text);
-    }
+  protected void type(WebElement element, String text) {
+    wait.until(ExpectedConditions.visibilityOf(element));
+    element.clear();
+    element.sendKeys(text);
+  }
 
-        protected String getText(WebElement element) {
-            wait.until(ExpectedConditions.visibilityOf(element));
-            return element.getText();
-        }
+  protected String getText(WebElement element) {
+    wait.until(ExpectedConditions.visibilityOf(element));
+    return element.getText();
+  }
 }

--- a/src/test/java/com/automation/pages/LoginPage.java
+++ b/src/test/java/com/automation/pages/LoginPage.java
@@ -7,31 +7,30 @@ import org.openqa.selenium.support.PageFactory;
 
 public class LoginPage extends BasePage {
 
-    @FindBy(id = "user-name")
-    private WebElement usernameField;
+  @FindBy(id = "user-name")
+  private WebElement usernameField;
 
-    @FindBy(id = "password")
-    private WebElement passwordField;
+  @FindBy(id = "password")
+  private WebElement passwordField;
 
-    @FindBy(id = "login-button")
-    private WebElement loginButton;
+  @FindBy(id = "login-button")
+  private WebElement loginButton;
 
-    @FindBy(css = ".error-message-container")
-    private WebElement errorMessage;
+  @FindBy(css = ".error-message-container")
+  private WebElement errorMessage;
 
-    public LoginPage(WebDriver driver) {
-        super(driver);
-        PageFactory.initElements(driver, this);
-    }
+  public LoginPage(WebDriver driver) {
+    super(driver);
+    PageFactory.initElements(driver, this);
+  }
 
-    public void login(String username, String password) {
-        type(usernameField, username);
-        type(passwordField, password);
-        click(loginButton);
-    }
+  public void login(String username, String password) {
+    type(usernameField, username);
+    type(passwordField, password);
+    click(loginButton);
+  }
 
-    public String getErrorMessage() {
-        return getText(errorMessage);
-    }
-
+  public String getErrorMessage() {
+    return getText(errorMessage);
+  }
 }

--- a/src/test/java/com/automation/runners/LoginRunner.java
+++ b/src/test/java/com/automation/runners/LoginRunner.java
@@ -1,26 +1,20 @@
 package com.automation.runners;
 
-import org.testng.annotations.DataProvider;
-
 import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
+import org.testng.annotations.DataProvider;
 
 @CucumberOptions(
     features = "src/test/resources/features",
     glue = "com.automation.stepdefinitions",
     plugin = {"pretty", "html:target/cucumber-reports.html"},
-    monochrome = true
-)
+    monochrome = true)
 public class LoginRunner extends AbstractTestNGCucumberTests {
 
-    /**
-     * Provides Cucumber scenarios as a TestNG DataProvider 
-     * with parallel execution enabled.
-     */
-    @Override
-    @DataProvider(parallel=true)
-    public Object[][] scenarios() {
-        return super.scenarios();
-    }
+  /** Provides Cucumber scenarios as a TestNG DataProvider with parallel execution enabled. */
+  @Override
+  @DataProvider(parallel = true)
+  public Object[][] scenarios() {
+    return super.scenarios();
+  }
 }
-

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -1,25 +1,24 @@
 package com.automation.stepdefinitions;
 
 import com.automation.base.BaseTest;
-
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 
 public class Hooks {
 
-    private final BaseTest baseTest;
+  private final BaseTest baseTest;
 
-    public Hooks(BaseTest baseTest) {
-        this.baseTest = baseTest;
-    }
+  public Hooks(BaseTest baseTest) {
+    this.baseTest = baseTest;
+  }
 
-    @Before
-    public void setUp() {
-        baseTest.setUp();
-    }
+  @Before
+  public void setUp() {
+    baseTest.setUp();
+  }
 
-    @After public void tearDown() {
-        baseTest.tearDown();
-    }
-
+  @After
+  public void tearDown() {
+    baseTest.tearDown();
+  }
 }

--- a/src/test/java/com/automation/stepdefinitions/LoginSteps.java
+++ b/src/test/java/com/automation/stepdefinitions/LoginSteps.java
@@ -6,54 +6,53 @@ import com.automation.base.BaseTest;
 import com.automation.pages.LoginPage;
 import com.automation.testdata.LoginErrorMessages;
 import com.automation.utils.ConfigReader;
-
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
-
 public class LoginSteps {
 
-    private LoginPage loginPage;
-    private final BaseTest baseTest;
+  private LoginPage loginPage;
+  private final BaseTest baseTest;
 
-    public LoginSteps(BaseTest baseTest) {
-        this.baseTest = baseTest;
-    }
+  public LoginSteps(BaseTest baseTest) {
+    this.baseTest = baseTest;
+  }
 
-    @Given("the user is on the login page")
-    public void theUserIsOnTheLoginPage() {
-        baseTest.getDriver().get(ConfigReader.get("BASE_URL"));
-        loginPage = new LoginPage(baseTest.getDriver());
-    }
+  @Given("the user is on the login page")
+  public void theUserIsOnTheLoginPage() {
+    baseTest.getDriver().get(ConfigReader.get("BASE_URL"));
+    loginPage = new LoginPage(baseTest.getDriver());
+  }
 
-    @When("they login with valid credentials")
-    public void theyLogInWithValidCredentials() {
-        loginPage.login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("PASSWORD"));
-    }
+  @When("they login with valid credentials")
+  public void theyLogInWithValidCredentials() {
+    loginPage.login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("PASSWORD"));
+  }
 
-    @When("they login with locked out credentials")
-    public void theyLoginWithLockedOutCredentials() {
-        loginPage.login(ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"));
-    }
+  @When("they login with locked out credentials")
+  public void theyLoginWithLockedOutCredentials() {
+    loginPage.login(ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"));
+  }
 
-    @When("they login with invalid credentials")
-    public void theyLoginWithInvalidCredentials() {
-        loginPage.login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"));
-    }
+  @When("they login with invalid credentials")
+  public void theyLoginWithInvalidCredentials() {
+    loginPage.login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"));
+  }
 
-    @Then("they should be redirected to the inventory page")
-    public void theyShouldBeRedirectedToTheInventoryPage() {
-        assertThat(baseTest.getDriver().getCurrentUrl()).isEqualTo(ConfigReader.get("BASE_URL") + ConfigReader.get("INVENTORY_PATH"));
-    }
+  @Then("they should be redirected to the inventory page")
+  public void theyShouldBeRedirectedToTheInventoryPage() {
+    assertThat(baseTest.getDriver().getCurrentUrl())
+        .isEqualTo(ConfigReader.get("BASE_URL") + ConfigReader.get("INVENTORY_PATH"));
+  }
 
-    @Then("they should see a locked out error message")
-    public void theyShouldSeeALockedOutMessage() {
-        assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.LOCKED_OUT);
-    }
+  @Then("they should see a locked out error message")
+  public void theyShouldSeeALockedOutMessage() {
+    assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.LOCKED_OUT);
+  }
 
-    @Then("they should see an invalid credentials error message")
-    public void theyShouldSeeAnInvalidCredentialsErrorMessage() {
-        assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.INVALID_CREDENTIALS);
-    }
+  @Then("they should see an invalid credentials error message")
+  public void theyShouldSeeAnInvalidCredentialsErrorMessage() {
+    assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.INVALID_CREDENTIALS);
+  }
 }

--- a/src/test/java/com/automation/testdata/LoginErrorMessages.java
+++ b/src/test/java/com/automation/testdata/LoginErrorMessages.java
@@ -2,11 +2,11 @@ package com.automation.testdata;
 
 public final class LoginErrorMessages {
 
-    public static final String LOCKED_OUT = "Sorry, this user has been locked out";
-    public static final String INVALID_CREDENTIALS = "Username and password do not match any user in this service";
+  public static final String LOCKED_OUT = "Sorry, this user has been locked out";
+  public static final String INVALID_CREDENTIALS =
+      "Username and password do not match any user in this service";
 
-    private LoginErrorMessages() {
-        // Utility class - prevent instantiation
-    }
-    
+  private LoginErrorMessages() {
+    // Utility class - prevent instantiation
+  }
 }

--- a/src/test/java/com/automation/testdata/LoginScenario.java
+++ b/src/test/java/com/automation/testdata/LoginScenario.java
@@ -1,9 +1,8 @@
 package com.automation.testdata;
 
 public record LoginScenario(String name, String username, String password, String expectedError) {
-    @Override
-    public String toString() {
-        return name;
-    }
+  @Override
+  public String toString() {
+    return name;
+  }
 }
-

--- a/src/test/java/com/automation/tests/LoginTest.java
+++ b/src/test/java/com/automation/tests/LoginTest.java
@@ -1,50 +1,62 @@
 package com.automation.tests;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import com.automation.base.BaseTest;
 import com.automation.pages.LoginPage;
 import com.automation.testdata.LoginErrorMessages;
 import com.automation.testdata.LoginScenario;
 import com.automation.utils.ConfigReader;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 public class LoginTest extends BaseTest {
 
-    private static final ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
-    
-    @BeforeMethod
-    public void setUpPage() {
-        getDriver().get(ConfigReader.get("BASE_URL"));
-        loginPage.set(new LoginPage(getDriver()));
-    }
+  private static final ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
 
-    @Test
-    public void successfulLoginTest() {
-        loginPage.get().login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("PASSWORD"));
-        assertThat(getDriver().getCurrentUrl()).isEqualTo(ConfigReader.get("BASE_URL") + ConfigReader.get("INVENTORY_PATH"));
-    }
+  @BeforeMethod
+  public void setUpPage() {
+    getDriver().get(ConfigReader.get("BASE_URL"));
+    loginPage.set(new LoginPage(getDriver()));
+  }
 
-    @Test(dataProvider="failedLoginData")
-    public void failedLoginTest(LoginScenario scenario) {
-        loginPage.get().login(scenario.username(), scenario.password());
-        assertThat(loginPage.get().getErrorMessage()).contains(scenario.expectedError());
-    }
+  @Test
+  public void successfulLoginTest() {
+    loginPage.get().login(ConfigReader.get("STANDARD_USER"), ConfigReader.get("PASSWORD"));
+    assertThat(getDriver().getCurrentUrl())
+        .isEqualTo(ConfigReader.get("BASE_URL") + ConfigReader.get("INVENTORY_PATH"));
+  }
 
-    @DataProvider(name = "failedLoginData")
-    public Object[][] failedLoginData() {
-        return new Object[][] {
-        {new LoginScenario("locked out user", ConfigReader.get("LOCKED_OUT_USER"), ConfigReader.get("PASSWORD"), LoginErrorMessages.LOCKED_OUT)},
-        {new LoginScenario("invalid password", ConfigReader.get("STANDARD_USER"), ConfigReader.get("INVALID_PASSWORD"), LoginErrorMessages.INVALID_CREDENTIALS)}
-        };
-    }
+  @Test(dataProvider = "failedLoginData")
+  public void failedLoginTest(LoginScenario scenario) {
+    loginPage.get().login(scenario.username(), scenario.password());
+    assertThat(loginPage.get().getErrorMessage()).contains(scenario.expectedError());
+  }
 
-     @AfterMethod(alwaysRun=true)
-     public void tearDownPage()  {
-        loginPage.remove();
-     }
+  @DataProvider(name = "failedLoginData")
+  public Object[][] failedLoginData() {
+    return new Object[][] {
+      {
+        new LoginScenario(
+            "locked out user",
+            ConfigReader.get("LOCKED_OUT_USER"),
+            ConfigReader.get("PASSWORD"),
+            LoginErrorMessages.LOCKED_OUT)
+      },
+      {
+        new LoginScenario(
+            "invalid password",
+            ConfigReader.get("STANDARD_USER"),
+            ConfigReader.get("INVALID_PASSWORD"),
+            LoginErrorMessages.INVALID_CREDENTIALS)
+      }
+    };
+  }
 
- }
+  @AfterMethod(alwaysRun = true)
+  public void tearDownPage() {
+    loginPage.remove();
+  }
+}

--- a/src/test/java/com/automation/utils/ConfigReader.java
+++ b/src/test/java/com/automation/utils/ConfigReader.java
@@ -4,27 +4,24 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.Properties;
 
-
-
 public class ConfigReader {
 
-    private static final Properties properties = new Properties();
+  private static final Properties properties = new Properties();
 
-    static {
-        try {
-            FileInputStream file = new FileInputStream("src/test/resources/config.properties");
-            properties.load(file);
-        } catch (IOException e) {
-            throw new RuntimeException("Could not load config.properties", e);
-        }
+  static {
+    try {
+      FileInputStream file = new FileInputStream("src/test/resources/config.properties");
+      properties.load(file);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not load config.properties", e);
     }
+  }
 
-    public static String get(String key) {
+  public static String get(String key) {
     String env = System.getenv(key);
     if (env != null) {
-        return env;
+      return env;
     }
     return properties.getProperty(key);
-}
-    
+  }
 }


### PR DESCRIPTION
## Summary
Introduces Spotless with Google Java Format and applies a one-time
mass reformat across the codebase. The `check` goal is not yet bound
to the build lifecycle - that follows in a separate PR so master
stays green between merges.

## Changes
- Added `spotless-maven-plugin` 3.4.0 to `pom.xml` with Google Java
  Format, unused import removal, import ordering, annotation
  formatting, and pom sorting
- Ran `mvn spotless:apply` across all Java sources (2-space indent,
  alphabetical single-block imports)
- Added `.git-blame-ignore-revs` so `git blame` skips the reformat commit

## Testing
- `mvn spotless:check` — green
- `mvn test` — all 6 tests pass (3 TestNG, 3 Cucumber)
- Reviewed diff manually; confirmed no behavioural changes, whitespace
  and import order only

## Notes for reviewer
The reformat commit is large but trivial. To review efficiently, focus
on the `pom.xml` change and the `.git-blame-ignore-revs` addition -
everything else is mechanical formatting applied by the tool.

To make your local `git blame` ignore the reformat commit:
git config blame.ignoreRevsFile .git-blame-ignore-revs

refs #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Applied consistent code formatting and indentation standards across all test files.

* **Chores**
  * Added code formatting configuration to the build pipeline.
  * Updated git blame configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->