### PR TITLE
Enforce spotless formatting check in build and ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
-      - name: Run tests
-        run: mvn test
+      - name: Build and test
+        run: mvn verify
         env:
           HEADLESS: true

--- a/README.md
+++ b/README.md
@@ -55,6 +55,51 @@ All environment configuration lives in `src/test/resources/config.properties`.
 > **Note:** In production, sensitive values such as passwords and URLs should
 > be stored as environment variables or a secrets manager, never committed to Git.
 
+## Code Formatting
+
+Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless)
+using [Google Java Format](https://github.com/google/google-java-format).
+The `spotless:check` goal is bound to Maven's `validate` phase, so any
+formatting violation fails the build before tests run.
+
+### Before pushing
+
+Run the full build locally — this runs the formatting check, tests, and
+packaging in one command:
+
+```bash
+mvn verify
+```
+
+### Fixing violations
+
+If Spotless reports violations, auto-fix them with:
+
+```bash
+mvn spotless:apply
+```
+
+Then re-run `mvn verify` to confirm everything is clean.
+
+### IDE integration (optional)
+
+For automatic formatting on save, install a Google Java Format plugin:
+- IntelliJ IDEA: [google-java-format plugin](https://plugins.jetbrains.com/plugin/8527-google-java-format)
+- VS Code: [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java) + google-java-format formatter
+
+### Git blame
+
+A mass reformat commit exists in the history (PR for #40). To make
+`git blame` skip it and show the original authoring commits, run
+this once per clone:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+GitHub's web UI respects `.git-blame-ignore-revs` automatically, so
+this is only needed for local blame.
+
 ## Git Convention
 
 Commits follow the Conventional Commits standard:

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,15 @@
             <sortPom/>
           </pom>
         </configuration>
+        <executions>
+          <execution>
+            <id>spotless-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>validate</phase>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## Summary
Enforces Spotless formatting checks as part of the build and CI pipeline. `spotless:check` is bound to Maven's `validate` phase so formatting violations fail the build before compile and tests run — giving fast feedback. CI now runs `mvn verify` on every push and pull request so the gate runs automatically, and the README documents the new workflow for contributors.

Together with the PR for the earlier half of #40 (plugin + mass reformat),
this completes automated formatting enforcement for the repo.

## Changes
- `pom.xml` — added `<executions>` block binding `spotless:check` to the `validate` phase
- `.github/workflows/ci.yml` — changed `mvn test` to `mvn verify` and renamed the step from "Run tests" to "Build and test" so CI failures label correctly
- `README.md` — added a Code Formatting section covering the standard (Google Java Format), the pre-push command (`mvn verify`), auto-fixing violations (`mvn spotless:apply`), optional IDE integration, and the  `git blame.ignoreRevsFile` setup for local `git blame`

## Testing

**Positive path:**
- `mvn verify` — BUILD SUCCESS, `spotless:check` runs in validate phase before compile, all 6 tests pass (3 TestNG, 3 Cucumber)

**Negative path (deliberate violation test):**
- Introduced a whitespace violation in `LoginPage.java`
- Ran `mvn verify` — build failed at the validate phase with Spotless reporting the violation. Compile and tests did not run, confirming fast failure as designed
- Ran `mvn spotless:apply` to auto-fix
- Ran `mvn verify` — BUILD SUCCESS, gate recovered cleanly

Closes #40