### PR TITLE
Add logging infrastructure (#10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,21 @@
       <version>7.15.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.13</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.23.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <version>2.23.1</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+    <Properties>
+        <Property name="logPattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n</Property>
+        <Property name="logDir">target/logs</Property>
+    </Properties>
+
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="${logPattern}"/>
+        </Console>
+
+        <RollingFile name="File"
+                     fileName="${logDir}/automation.log"
+                     filePattern="${logDir}/automation-%d{yyyy-MM-dd}-%i.log.gz">
+            <PatternLayout pattern="${logPattern}"/>
+            <Policies>
+                <OnStartupTriggeringPolicy/>
+                <SizeBasedTriggeringPolicy size="10 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="10"/>
+        </RollingFile>
+    </Appenders>
+
+    <Loggers>
+        <Logger name="com.automation" level="${sys:logLevel:-INFO}" additivity="false">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Logger>
+
+        <Root level="WARN">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## Summary
Adds the logging foundation for the framework: SLF4J API, Log4j 2 core, and the SLF4J-to-Log4j2 bridge, plus a log4j2.xml configuration with console and rolling file appenders. No application loggers are wired into framework classes in this PR — that work is deferred to a follow-up issue.

## Changes
- Added three dependencies to pom.xml:
  - org.slf4j:slf4j-api (facade)
  - org.apache.logging.log4j:log4j-core (implementation)
  - org.apache.logging.log4j:log4j-slf4j2-impl (bridge)
- Added src/main/resources/log4j2.xml with:
  - Console appender (SYSTEM_OUT)
  - RollingFile appender writing to target/logs/automation.log, 
    rolling on startup and at 10 MB, keeping the last 10 compressed
  - Pattern layout including timestamp, thread name, level, logger 
    name, and message
  - com.automation logger configured via ${sys:logLevel:-INFO} 
    with additivity disabled
  - Root logger at WARN to suppress Selenium/Cucumber internals

## Why only the foundation?
The original issue scope included wiring application loggers and making the level configurable via config.properties. During implementation I hit a class initialisation ordering problem: Log4j 2 bootstraps the first time any class calls LoggerFactory.getLogger, and because Selenium/Cucumber internals are loaded before BaseTest (and therefore before ConfigReader), any attempt to set the system property from ConfigReader's static initialiser runs too late — Log4j 2 has already locked in the default level.

The clean fix requires refactoring ConfigReader for test-ability and explicit initialisation control, which is out of scope for a logging ticket. Rather than build workarounds on top of the existing design, I've rescoped #10 to cover only the additive infrastructure (which is decoupled from ConfigReader) and filed follow-up issues for the refactor and the deferred logger wiring.

## Testing
- mvn verify passes
- target/logs/automation.log is created during test runs
- All 6 existing tests continue to pass
- Existing Selenium/Cucumber console output is routed through Log4j 2 
  at WARN and above, confirming the config is picked up

## Related Issues
- Closes #10 (rescoped)
- Blocked follow-up: #47  (ConfigReader refactor)
- Deferred work: #48  (wire loggers + configurable level)

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added logging framework with SLF4J and Log4j 2. Logs are written to both console and file with automatic daily rotation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->