### PR TITLE
Feature/48 configurable log level

### DIFF
--- a/src/test/java/com/automation/utils/ConfigReader.java
+++ b/src/test/java/com/automation/utils/ConfigReader.java
@@ -2,6 +2,7 @@ package com.automation.utils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
@@ -18,6 +19,7 @@ public class ConfigReader {
 
   public ConfigReader(String classpathResource) {
     this(loadFromClasspath(classpathResource), System::getenv);
+    applyLogLevel();
   }
 
   private static Properties loadFromClasspath(String resource) {
@@ -41,7 +43,18 @@ public class ConfigReader {
     return properties.getProperty(key);
   }
 
-  void applyLogLevel() {
-    // TODO: implement
+  final void applyLogLevel() {
+    String logLevel = get("LOG_LEVEL");
+    if (logLevel == null) {
+      System.err.println("LOG_LEVEL not set, defaulting to INFO");
+      logLevel = "INFO";
+    }
+    logLevel = logLevel.trim();
+    if (logLevel.isEmpty()) {
+      System.err.println("LOG_LEVEL not set, defaulting to INFO");
+      logLevel = "INFO";
+    }
+    logLevel = logLevel.toUpperCase(Locale.ROOT);
+    System.setProperty("logLevel", logLevel);
   }
 }

--- a/src/test/java/com/automation/utils/ConfigReader.java
+++ b/src/test/java/com/automation/utils/ConfigReader.java
@@ -40,4 +40,8 @@ public class ConfigReader {
     }
     return properties.getProperty(key);
   }
+
+  void applyLogLevel() {
+    // TODO: implement
+  }
 }

--- a/src/test/java/com/automation/utils/ConfigReader.java
+++ b/src/test/java/com/automation/utils/ConfigReader.java
@@ -17,6 +17,12 @@ public class ConfigReader {
     this.envLookup = Objects.requireNonNull(envLookup, "envLookup must not be null");
   }
 
+  /**
+   * Creates a ConfigReader from a classpath resource with system environment variable override.
+   *
+   * <p>Calls {@link #applyLogLevel()} to set the logLevel system property before any Logger is
+   * created.
+   */
   public ConfigReader(String classpathResource) {
     this(loadFromClasspath(classpathResource), System::getenv);
     applyLogLevel();
@@ -43,6 +49,13 @@ public class ConfigReader {
     return properties.getProperty(key);
   }
 
+  /**
+   * Reads LOG_LEVEL from config, normalises it, and sets the logLevel system property for Log4j 2.
+   *
+   * <p>Trims whitespace and converts to uppercase (Locale.ROOT). If LOG_LEVEL is missing or empty,
+   * defaults to INFO and emits a warning to stderr. Must be called before any Logger is created so
+   * that log4j2.xml's {@code ${sys:logLevel:-INFO}} resolves correctly.
+   */
   final void applyLogLevel() {
     String logLevel = get("LOG_LEVEL");
     if (logLevel == null) {

--- a/src/test/java/com/automation/utils/ConfigReaderTest.java
+++ b/src/test/java/com/automation/utils/ConfigReaderTest.java
@@ -71,6 +71,12 @@ class ConfigReaderTest {
   }
 
   @Test
+  void constructor_shouldApplyLogLevelFromClasspath() {
+    new ConfigReader("config.properties");
+    assertThat(System.getProperty("logLevel")).isNotNull();
+  }
+
+  @Test
   void applyLogLevel_shouldTrimWhitespace() {
     Properties props = new Properties();
     props.setProperty("LOG_LEVEL", "  debug  ");

--- a/src/test/java/com/automation/utils/ConfigReaderTest.java
+++ b/src/test/java/com/automation/utils/ConfigReaderTest.java
@@ -2,11 +2,25 @@ package com.automation.utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Properties;
 import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ConfigReaderTest {
+
+  @BeforeEach
+  void clearLogLevel() {
+    System.clearProperty("logLevel");
+  }
+
+  @AfterEach
+  void resetLogLevel() {
+    System.clearProperty("logLevel");
+  }
 
   @Test
   void shouldReturnPropertyValue() {
@@ -54,5 +68,79 @@ class ConfigReaderTest {
     ConfigReader config = new ConfigReader(props, emptyString);
     String result = config.get("KEY");
     assertThat(result).isEqualTo("VALUE");
+  }
+
+  @Test
+  void applyLogLevel_shouldTrimWhitespace() {
+    Properties props = new Properties();
+    props.setProperty("LOG_LEVEL", "  debug  ");
+    Function<String, String> noEnv = key -> null;
+    ConfigReader config = new ConfigReader(props, noEnv);
+
+    config.applyLogLevel();
+
+    assertThat(System.getProperty("logLevel")).isEqualTo("DEBUG");
+  }
+
+  @Test
+  void applyLogLevel_shouldNormaliseToUpperCase() {
+    Properties props = new Properties();
+    props.setProperty("LOG_LEVEL", "WaRn");
+    Function<String, String> noEnv = key -> null;
+    ConfigReader config = new ConfigReader(props, noEnv);
+
+    config.applyLogLevel();
+
+    assertThat(System.getProperty("logLevel")).isEqualTo("WARN");
+  }
+
+  @Test
+  void applyLogLevel_shouldDefaultToInfoWhenMissing() {
+    Properties props = new Properties();
+    Function<String, String> noEnv = key -> null;
+    ConfigReader config = new ConfigReader(props, noEnv);
+
+    config.applyLogLevel();
+
+    assertThat(System.getProperty("logLevel")).isEqualTo("INFO");
+  }
+
+  @Test
+  void applyLogLevel_shouldDefaultToInfoWhenEmpty() {
+    Properties props = new Properties();
+    props.setProperty("LOG_LEVEL", "");
+    Function<String, String> noEnv = key -> null;
+    ConfigReader config = new ConfigReader(props, noEnv);
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    PrintStream originalErr = System.err;
+    System.setErr(new PrintStream(errContent));
+    try {
+      config.applyLogLevel();
+      String stderrOutput = errContent.toString();
+      assertThat(System.getProperty("logLevel")).isEqualTo("INFO");
+      assertThat(stderrOutput).contains("LOG_LEVEL not set, defaulting to INFO");
+    } finally {
+      System.setErr(originalErr);
+    }
+  }
+
+  @Test
+  void applyLogLevel_shouldWarnToStderrWhenMissing() {
+    Properties props = new Properties();
+    Function<String, String> noEnv = key -> null;
+    ConfigReader config = new ConfigReader(props, noEnv);
+
+    ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    PrintStream originalErr = System.err;
+    System.setErr(new PrintStream(errContent));
+
+    try {
+      config.applyLogLevel();
+      String stderrOutput = errContent.toString();
+      assertThat(stderrOutput).contains("LOG_LEVEL not set, defaulting to INFO");
+    } finally {
+      System.setErr(originalErr);
+    }
   }
 }

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -16,3 +16,6 @@ LOCKED_OUT_USER=locked_out_user
 # ── Test User Credentials ────────────────────────────────────
 PASSWORD=secret_sauce
 INVALID_PASSWORD=wrong_password
+
+# ── Log Level ─────────────────────────────────────
+LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary
Added configurable `logLevel` for Log4J2 so that log verbosity can be changed without editing `log4j2.xml` directly. Capitalisation errors and whitespace issues are caught and fixed by the `applyLogLevel` method in `ConfigReader.java`. The convenience constructor calls `applyLogLevel()` which sets the `logLevel` system property before any Logger is created, so `log4j2.xml's` `${sys:logLevel:-INFO}` resolves correctly. This can be set using system variables or via the `config.properties` file.  

## Changes
- Created unit tests to check whitespace is trimmed, Case is normalised to uppercase, Missing `LOG_LEVEL` defaults to `INFO`, Empty string is defaulted to `INFO`. stderr warning is emitted when defaulting
- Created `applyLogLevel` method to get and set log level before any Logger is initialised. 
- Added `LOG_LEVEL` variable to `config.properties`

## Testing
- Round trip verified the Logs manually by setting the log level to empty and seeing the syserr message printed in log. Changed log level to INFO and syserr message were no longer present.
- mvn verify ran full suite with 10 unit (surefire) passes and 6 integration (failsafe) passes. 

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added log-level configuration support; applications can now specify logging verbosity via the LOG_LEVEL property, which automatically defaults to INFO when unspecified or empty.

* **Tests**
  * Enhanced test coverage for log-level configuration behaviour, including whitespace handling and value normalisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->