### PR TITLE
Feature/51 slf4j loggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ All environment configuration lives in `src/test/resources/config.properties`.
 > **Note:** In production, sensitive values such as passwords and URLs should
 > be stored as environment variables or a secrets manager, never committed to Git.
 
+## Logging
+
+Log4j2 is used to implement logging with SLF4J used to write the log messages.
+
+Log level can be configured by updating `src/test/resources/config.properties` or by passing in the environment variable when running `mvn verify`
+e.g `$ LOG_LEVEL=WARN mvn verify`. The default level is `INFO`.
+
+Logs are written to both the console and to files in `target/logs/`, which rotate at 10 MB.
+
+Valid log levels are DEBUG, INFO, WARN, and ERROR.
+
+
 ## Code Formatting
 
 Code formatting is enforced by [Spotless](https://github.com/diffplug/spotless)
@@ -147,7 +159,7 @@ Pull request workflow:
 - [x] Cucumber BDD feature files and step definitions
 - [x] TestNG DataProvider driven tests
 - [ ] Screenshot on failure
-- [ ] Log4j logging
+- [x] Log4j logging
 - [ ] WireMock IAM API mocking with REST Assured
 - [ ] Add CartPage and cart tests
 - [ ] Add CheckoutPage and end to end checkout tests

--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ All environment configuration lives in `src/test/resources/config.properties`.
 
 ## Logging
 
-Log4j2 is used to implement logging with SLF4J used to write the log messages.
+SLF4J is used as the logging API, with Log4j2 as the implementation.
 
 Log level can be configured by updating `src/test/resources/config.properties` or by passing in the environment variable when running `mvn verify`
-e.g `$ LOG_LEVEL=WARN mvn verify`. The default level is `INFO`.
+e.g. `LOG_LEVEL=WARN mvn verify`. The default level is `INFO`.
 
 Logs are written to both the console and to files in `target/logs/`, which rotate at 10 MB.
 

--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -9,12 +9,19 @@ import org.openqa.selenium.edge.EdgeDriver;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 
+/**
+ * Base class for all test classes. Manages the WebDriver lifecycle and provides access to shared
+ * configuration.
+ */
 public class BaseTest {
 
   private static final ThreadLocal<WebDriver> driver = new ThreadLocal<>();
+  private static final Logger LOG = LoggerFactory.getLogger(BaseTest.class);
   private final ConfigReader configReader = new ConfigReader("config.properties");
 
   public WebDriver getDriver() {
@@ -25,12 +32,14 @@ public class BaseTest {
     return configReader;
   }
 
+  /** Sets up driver before test */
   @BeforeMethod
   public void setUp() {
     String configuredBrowser = configReader.get("BROWSER");
     String browser = configuredBrowser == null ? "firefox" : configuredBrowser.toLowerCase();
     WebDriver webDriver;
 
+    LOG.info("Starting browser: {} (Headless: {})", browser, configReader.get("HEADLESS"));
     switch (browser) {
       case "chrome":
         WebDriverManager.chromedriver().setup();
@@ -64,18 +73,21 @@ public class BaseTest {
     driver.set(webDriver);
   }
 
+  /** Closes down driver once test has completed */
   @AfterMethod(alwaysRun = true)
   public void tearDown() {
     WebDriver currentDriver = driver.get();
     try {
       if (currentDriver != null) {
         currentDriver.quit();
+        LOG.info("Browser closed");
       }
     } finally {
       driver.remove();
     }
   }
 
+  /** Checks headless argument for browser */
   public boolean isHeadless() {
     return "true".equalsIgnoreCase(configReader.get("HEADLESS"));
   }

--- a/src/test/java/com/automation/pages/BasePage.java
+++ b/src/test/java/com/automation/pages/BasePage.java
@@ -5,8 +5,15 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Base class for all page objects. Provides common element interaction methods with explicit waits.
+ */
 public class BasePage {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BasePage.class);
 
   protected WebDriver driver;
   protected WebDriverWait wait;
@@ -16,18 +23,24 @@ public class BasePage {
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
   }
 
+  /** Waits for the element to be clickable, then clicks it. */
   protected void click(WebElement element) {
+    LOG.debug("Clicking element: {}", element);
     wait.until(ExpectedConditions.elementToBeClickable(element));
     element.click();
   }
 
+  /** Waits for the element to be visible, clears it, then types the given text. */
   protected void type(WebElement element, String text) {
+    LOG.debug("Typing into element: {}", element);
     wait.until(ExpectedConditions.visibilityOf(element));
     element.clear();
     element.sendKeys(text);
   }
 
+  /** Waits for the element to be visible, then returns its text content. */
   protected String getText(WebElement element) {
+    LOG.debug("Getting text from element: {}", element);
     wait.until(ExpectedConditions.visibilityOf(element));
     return element.getText();
   }

--- a/src/test/java/com/automation/pages/LoginPage.java
+++ b/src/test/java/com/automation/pages/LoginPage.java
@@ -4,8 +4,15 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Page object for the SauceDemo login page. Provides methods to log in and retrieve error messages.
+ */
 public class LoginPage extends BasePage {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LoginPage.class);
 
   @FindBy(id = "user-name")
   private WebElement usernameField;
@@ -24,12 +31,15 @@ public class LoginPage extends BasePage {
     PageFactory.initElements(driver, this);
   }
 
+  /** Inputs provided username and password and clicks the login button. */
   public void login(String username, String password) {
+    LOG.info("Logging in with username: {}", username);
     type(usernameField, username);
     type(passwordField, password);
     click(loginButton);
   }
 
+  /** Returns error message when login fails. */
   public String getErrorMessage() {
     return getText(errorMessage);
   }

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -31,7 +31,10 @@ public class Hooks {
   /** Closes down driver once cucumber test has completed */
   @After
   public void tearDown(Scenario scenario) {
-    baseTest.tearDown();
-    LOG.info("Finished scenario: {}", scenario.getName());
+    try {
+      baseTest.tearDown();
+    } finally {
+      LOG.info("Finished scenario: {}", scenario.getName());
+    }
   }
 }

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -3,8 +3,17 @@ package com.automation.stepdefinitions;
 import com.automation.base.BaseTest;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Cucumber lifecycle hooks. Manages browser setup and teardown around each scenario by delegating
+ * to BaseTest.
+ */
 public class Hooks {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Hooks.class);
 
   private final BaseTest baseTest;
 
@@ -12,13 +21,17 @@ public class Hooks {
     this.baseTest = baseTest;
   }
 
+  /** Sets up driver before cucumber test */
   @Before
-  public void setUp() {
+  public void setUp(Scenario scenario) {
+    LOG.info("Starting scenario: {}", scenario.getName());
     baseTest.setUp();
   }
 
+  /** Closes down driver once cucumber test has completed */
   @After
-  public void tearDown() {
+  public void tearDown(Scenario scenario) {
     baseTest.tearDown();
+    LOG.info("Finished scenario: {}", scenario.getName());
   }
 }

--- a/src/test/java/com/automation/stepdefinitions/LoginSteps.java
+++ b/src/test/java/com/automation/stepdefinitions/LoginSteps.java
@@ -9,9 +9,16 @@ import com.automation.utils.ConfigReader;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Cucumber step definitions for login feature scenarios. Maps Gherkin steps to actions on the
+ * LoginPage.
+ */
 public class LoginSteps {
 
+  private static final Logger LOG = LoggerFactory.getLogger(LoginSteps.class);
   private LoginPage loginPage;
   private final BaseTest baseTest;
   private final ConfigReader config;
@@ -21,9 +28,12 @@ public class LoginSteps {
     this.config = baseTest.getConfigReader();
   }
 
+  /** Navigates to the SauceDemo login page and initialises the page object. */
   @Given("the user is on the login page")
   public void theUserIsOnTheLoginPage() {
-    baseTest.getDriver().get(config.get("BASE_URL"));
+    String baseUrl = config.get("BASE_URL");
+    LOG.info("Navigating to base page. URL: {}", baseUrl);
+    baseTest.getDriver().get(baseUrl);
     loginPage = new LoginPage(baseTest.getDriver());
   }
 
@@ -44,17 +54,22 @@ public class LoginSteps {
 
   @Then("they should be redirected to the inventory page")
   public void theyShouldBeRedirectedToTheInventoryPage() {
-    assertThat(baseTest.getDriver().getCurrentUrl())
-        .isEqualTo(config.get("BASE_URL") + config.get("INVENTORY_PATH"));
+    String currentUrl = baseTest.getDriver().getCurrentUrl();
+    LOG.info("Current URL: {}", currentUrl);
+    assertThat(currentUrl).isEqualTo(config.get("BASE_URL") + config.get("INVENTORY_PATH"));
   }
 
   @Then("they should see a locked out error message")
   public void theyShouldSeeALockedOutMessage() {
-    assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.LOCKED_OUT);
+    String errorMessage = loginPage.getErrorMessage();
+    LOG.info("Error message found: {}", errorMessage);
+    assertThat(errorMessage).contains(LoginErrorMessages.LOCKED_OUT);
   }
 
   @Then("they should see an invalid credentials error message")
   public void theyShouldSeeAnInvalidCredentialsErrorMessage() {
-    assertThat(loginPage.getErrorMessage()).contains(LoginErrorMessages.INVALID_CREDENTIALS);
+    String errorMessage = loginPage.getErrorMessage();
+    LOG.info("Error message found: {}", errorMessage);
+    assertThat(errorMessage).contains(LoginErrorMessages.INVALID_CREDENTIALS);
   }
 }

--- a/src/test/java/com/automation/utils/ConfigReader.java
+++ b/src/test/java/com/automation/utils/ConfigReader.java
@@ -6,7 +6,15 @@ import java.util.Locale;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Function;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+/**
+ * Reads configuration from a classpath properties file with environment variable overrides.
+ * Environment variables take priority over file values, enabling CI and local configuration without
+ * code changes.
+ */
 public class ConfigReader {
 
   private final Properties properties;
@@ -26,6 +34,8 @@ public class ConfigReader {
   public ConfigReader(String classpathResource) {
     this(loadFromClasspath(classpathResource), System::getenv);
     applyLogLevel();
+    Logger log = LoggerFactory.getLogger(ConfigReader.class);
+    log.info("Config loaded - log level: {}", System.getProperty("logLevel"));
   }
 
   private static Properties loadFromClasspath(String resource) {
@@ -69,5 +79,6 @@ public class ConfigReader {
     }
     logLevel = logLevel.toUpperCase(Locale.ROOT);
     System.setProperty("logLevel", logLevel);
+    Configurator.reconfigure();
   }
 }


### PR DESCRIPTION
## Summary
Added SLF4J loggers to framework and page classes so that test execution can be traced and debugged from the log output.

## Changes
- Called Configurator.reconfigure() after logLevel System Property has been set to ensure configured log level is used.
- Method local logger added in ConfigReader.java to ensure log level is correctly set.
- Added SLF4J loggers to framework and page classes.
- Updated README file to contain section on Logging, contains details of configurable log levels, where logs are stored and how to configure. 

## Testing
- Round trip verified the Logs manually by setting the log level to DEBUG and WARN via environmental variable. Debug logs seen in logLevel:DEBUG and no logs in logLevel:WARN.
- mvn verify ran full suite with 11 unit (surefire) passes and 6 integration (failsafe) passes. 

Closes #51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README now documents logging setup: SLF4J with Log4j2, configurable log level (env/file), console and rotating file output, and allowed levels.
  * Added class/method Javadoc across the test suite.

* **Tests**
  * Broadened test logging: scenario-level logs, lifecycle start/stop messages, and detailed interaction-level debug/info logs.
  * Log-level reconfiguration supported at runtime for test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->