### PR TITLE
refactor: extract browser creation to DriverFactory refs #17

### DIFF
--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -1,14 +1,8 @@
 package com.automation.base;
 
 import com.automation.utils.ConfigReader;
-import io.github.bonigarcia.wdm.WebDriverManager;
+import com.automation.utils.DriverFactory;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.edge.EdgeDriver;
-import org.openqa.selenium.edge.EdgeOptions;
-import org.openqa.selenium.firefox.FirefoxDriver;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -37,40 +31,8 @@ public class BaseTest {
   public void setUp() {
     String configuredBrowser = configReader.get("BROWSER");
     String browser = configuredBrowser == null ? "firefox" : configuredBrowser.toLowerCase();
-    WebDriver webDriver;
-
-    LOG.info("Starting browser: {} (Headless: {})", browser, configReader.get("HEADLESS"));
-    switch (browser) {
-      case "chrome":
-        WebDriverManager.chromedriver().setup();
-        ChromeOptions chromeOptions = new ChromeOptions();
-        if (isHeadless()) {
-          chromeOptions.addArguments("--headless");
-        }
-        webDriver = new ChromeDriver(chromeOptions);
-        break;
-
-      case "edge":
-        WebDriverManager.edgedriver().setup();
-        EdgeOptions edgeOptions = new EdgeOptions();
-        if (isHeadless()) {
-          edgeOptions.addArguments("--headless");
-        }
-        webDriver = new EdgeDriver(edgeOptions);
-        break;
-      case "firefox":
-      default:
-        WebDriverManager.firefoxdriver().setup();
-        FirefoxOptions firefoxOptions = new FirefoxOptions();
-        if (isHeadless()) {
-          firefoxOptions.addArguments("--headless");
-        }
-        webDriver = new FirefoxDriver(firefoxOptions);
-        break;
-    }
-
-    webDriver.manage().window().maximize();
-    driver.set(webDriver);
+    boolean headless = "true".equalsIgnoreCase(configReader.get("HEADLESS"));
+    driver.set(DriverFactory.createDriver(browser, headless));
   }
 
   /** Closes down driver once test has completed */
@@ -85,10 +47,5 @@ public class BaseTest {
     } finally {
       driver.remove();
     }
-  }
-
-  /** Checks headless argument for browser */
-  public boolean isHeadless() {
-    return "true".equalsIgnoreCase(configReader.get("HEADLESS"));
   }
 }

--- a/src/test/java/com/automation/utils/DriverFactory.java
+++ b/src/test/java/com/automation/utils/DriverFactory.java
@@ -1,0 +1,61 @@
+package com.automation.utils;
+
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.edge.EdgeDriver;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.openqa.selenium.firefox.FirefoxDriver;
+import org.openqa.selenium.firefox.FirefoxOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Creates configured WebDriver instances for supported browsers */
+public class DriverFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DriverFactory.class);
+
+  private DriverFactory() {
+    // Utility class - prevent instantiation
+  }
+
+  /** Creates a WebDriver for the specified browser, optionally in headless mode */
+  public static WebDriver createDriver(String browser, boolean headless) {
+
+    WebDriver webDriver;
+
+    LOG.info("Starting browser: {} (Headless: {})", browser, headless);
+    switch (browser) {
+      case "chrome" -> {
+        WebDriverManager.chromedriver().setup();
+        ChromeOptions chromeOptions = new ChromeOptions();
+        if (headless) {
+          chromeOptions.addArguments("--headless");
+        }
+        webDriver = new ChromeDriver(chromeOptions);
+      }
+
+      case "edge" -> {
+        WebDriverManager.edgedriver().setup();
+        EdgeOptions edgeOptions = new EdgeOptions();
+        if (headless) {
+          edgeOptions.addArguments("--headless");
+        }
+        webDriver = new EdgeDriver(edgeOptions);
+      }
+      case "firefox" -> {
+        WebDriverManager.firefoxdriver().setup();
+        FirefoxOptions firefoxOptions = new FirefoxOptions();
+        if (headless) {
+          firefoxOptions.addArguments("--headless");
+        }
+        webDriver = new FirefoxDriver(firefoxOptions);
+      }
+      default -> throw new IllegalArgumentException("Unsupported browser: " + browser);
+    }
+
+    webDriver.manage().window().maximize();
+    return webDriver;
+  }
+}

--- a/src/test/java/com/automation/utils/DriverFactory.java
+++ b/src/test/java/com/automation/utils/DriverFactory.java
@@ -31,7 +31,7 @@ public class DriverFactory {
         WebDriverManager.chromedriver().setup();
         ChromeOptions chromeOptions = new ChromeOptions();
         if (headless) {
-          chromeOptions.addArguments("--headless");
+          chromeOptions.addArguments("--headless=new");
         }
         webDriver = new ChromeDriver(chromeOptions);
       }
@@ -40,7 +40,7 @@ public class DriverFactory {
         WebDriverManager.edgedriver().setup();
         EdgeOptions edgeOptions = new EdgeOptions();
         if (headless) {
-          edgeOptions.addArguments("--headless");
+          edgeOptions.addArguments("--headless=new");
         }
         webDriver = new EdgeDriver(edgeOptions);
       }


### PR DESCRIPTION
## Summary
Extracts WebDriver creation to a dedicated DriverFactory so that BaseTest only manages driver lifecycle, following the single responsibility principle.

## Changes
- Extracted browser creation from BaseTest to DriverFactory
- Threadlocal remains in BaseTest to satisfy SRP
- Removed isHeadless() from BaseTest
- Unsupported browser names now throw IllegalArgumentException instead of silently defaulting to Firefox
- Switched to arrow syntax in the switch statement

## Testing
- mvn verify ran full suite with 11 unit (surefire) passes and 6 integration (failsafe) passes. 

Closes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored test driver initialization to use a factory pattern for improved maintainability and consistency across browser configurations.
  * Centralised WebDriver creation logic, simplifying headless mode configuration for Chrome, Edge, and Firefox browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->