### PR TITLE
Feature/4 add screenshot on failure

### DIFF
--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -1,5 +1,6 @@
 package com.automation.base;
 
+import com.automation.reporting.ScreenshotListener;
 import com.automation.utils.ConfigReader;
 import com.automation.utils.DriverFactory;
 import org.openqa.selenium.WebDriver;
@@ -7,11 +8,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 
 /**
  * Base class for all test classes. Manages the WebDriver lifecycle and provides access to shared
  * configuration.
  */
+@Listeners(ScreenshotListener.class)
 public class BaseTest {
 
   private static final ThreadLocal<WebDriver> driver = new ThreadLocal<>();

--- a/src/test/java/com/automation/reporting/LocalScreenshotStore.java
+++ b/src/test/java/com/automation/reporting/LocalScreenshotStore.java
@@ -3,6 +3,7 @@ package com.automation.reporting;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,8 +22,13 @@ public class LocalScreenshotStore implements ScreenshotStore {
   /** {@inheritDoc} */
   @Override
   public void storeScreenshot(byte[] bytes, String filename) throws IOException {
+    Objects.requireNonNull(bytes, "bytes must not be null");
+    Objects.requireNonNull(filename, "filename must not be null");
     Files.createDirectories(outputDir);
-    Path filePath = outputDir.resolve(filename);
+    Path filePath = outputDir.resolve(filename).normalize();
+    if (!filePath.startsWith(outputDir.normalize())) {
+      throw new IOException("Path traversal detected: " + filename);
+    }
     Files.write(filePath, bytes);
     LOG.info("Screenshot saved: {}", filePath);
   }

--- a/src/test/java/com/automation/reporting/LocalScreenshotStore.java
+++ b/src/test/java/com/automation/reporting/LocalScreenshotStore.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 /** Saves screenshot bytes to the local filesystem. Implements {@link ScreenshotStore}. */
 public class LocalScreenshotStore implements ScreenshotStore {
 
+  public static final Path DEFAULT_DIR = Path.of("target/screenshots");
   private static final Logger LOG = LoggerFactory.getLogger(LocalScreenshotStore.class);
   private final Path outputDir;
 

--- a/src/test/java/com/automation/reporting/LocalScreenshotStore.java
+++ b/src/test/java/com/automation/reporting/LocalScreenshotStore.java
@@ -1,0 +1,28 @@
+package com.automation.reporting;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Saves screenshot bytes to the local filesystem. Implements {@link ScreenshotStore}. */
+public class LocalScreenshotStore implements ScreenshotStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LocalScreenshotStore.class);
+  private final Path outputDir;
+
+  /** Creates a store that saves screenshots to the specified directory. */
+  public LocalScreenshotStore(Path outputDir) {
+    this.outputDir = outputDir;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void storeScreenshot(byte[] bytes, String filename) throws IOException {
+    Files.createDirectories(outputDir);
+    Path filePath = outputDir.resolve(filename);
+    Files.write(filePath, bytes);
+    LOG.info("Screenshot saved: {}", filePath);
+  }
+}

--- a/src/test/java/com/automation/reporting/LocalScreenshotStoreTest.java
+++ b/src/test/java/com/automation/reporting/LocalScreenshotStoreTest.java
@@ -1,0 +1,23 @@
+package com.automation.reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/** Unit tests for LocalScreenshotStore */
+public class LocalScreenshotStoreTest {
+
+  @Test
+  void shouldSaveScreenshotinTempDir(@TempDir Path tempDir) throws IOException {
+    LocalScreenshotStore store = new LocalScreenshotStore(tempDir);
+    byte[] fakeImage = {10, 20, 30, 40, 50};
+    String filename = "test-screenshot.png";
+    store.storeScreenshot(fakeImage, filename);
+    Path expectedFile = tempDir.resolve(filename);
+    assertThat(expectedFile).exists();
+    assertThat(expectedFile).hasBinaryContent(fakeImage);
+  }
+}

--- a/src/test/java/com/automation/reporting/LocalScreenshotStoreTest.java
+++ b/src/test/java/com/automation/reporting/LocalScreenshotStoreTest.java
@@ -1,6 +1,7 @@
 package com.automation.reporting;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -19,5 +20,12 @@ public class LocalScreenshotStoreTest {
     Path expectedFile = tempDir.resolve(filename);
     assertThat(expectedFile).exists();
     assertThat(expectedFile).hasBinaryContent(fakeImage);
+  }
+
+  @Test
+  void shouldNotAllowTraversalFilename(@TempDir Path tempDir) throws IOException {
+    LocalScreenshotStore store = new LocalScreenshotStore(tempDir);
+    assertThatThrownBy(() -> store.storeScreenshot(new byte[1], "../../evil.png"))
+        .isInstanceOf(IOException.class);
   }
 }

--- a/src/test/java/com/automation/reporting/ScreenshotListener.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListener.java
@@ -1,0 +1,63 @@
+package com.automation.reporting;
+
+import com.automation.base.BaseTest;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+/** TestNG Listener that captures a screenshot on failure */
+public class ScreenshotListener implements ITestListener {
+
+  private final ScreenshotStore screenshotStore;
+  private static final Logger LOG = LoggerFactory.getLogger(ScreenshotListener.class);
+
+  /** No-arg constructor for TestNG registration. Saves to target/screenshots. */
+  public ScreenshotListener() {
+    this(new LocalScreenshotStore(Path.of("target/screenshots")));
+  }
+
+  /** Constructor for dependency injection in tests. */
+  public ScreenshotListener(ScreenshotStore screenshotStore) {
+    this.screenshotStore = screenshotStore;
+  }
+
+  /** Builds filename for screenshot on failure */
+  public static String buildFileName(String testName) {
+    return testName.replace(" ", "_")
+        + "_"
+        + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"))
+        + ".png";
+  }
+
+  @Override
+  public void onTestFailure(ITestResult result) {
+
+    if (!(result.getInstance() instanceof BaseTest baseTest)) {
+      LOG.warn("Instance not BaseTest");
+      return;
+    }
+
+    WebDriver driver = baseTest.getDriver();
+
+    if (driver == null) {
+      LOG.warn("Driver is null");
+      return;
+    }
+
+    byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+    String filename = buildFileName(result.getName());
+    try {
+      screenshotStore.storeScreenshot(screenshotBytes, filename);
+    } catch (IOException e) {
+      LOG.error("Failed to save screenshot: {}", filename, e);
+    }
+  }
+}

--- a/src/test/java/com/automation/reporting/ScreenshotListener.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListener.java
@@ -2,9 +2,6 @@ package com.automation.reporting;
 
 import com.automation.base.BaseTest;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -21,20 +18,12 @@ public class ScreenshotListener implements ITestListener {
 
   /** No-arg constructor for TestNG registration. Saves to target/screenshots. */
   public ScreenshotListener() {
-    this(new LocalScreenshotStore(Path.of("target/screenshots")));
+    this(new LocalScreenshotStore(LocalScreenshotStore.DEFAULT_DIR));
   }
 
   /** Constructor for dependency injection in tests. */
   public ScreenshotListener(ScreenshotStore screenshotStore) {
     this.screenshotStore = screenshotStore;
-  }
-
-  /** Builds filename for screenshot on failure */
-  public static String buildFileName(String testName) {
-    return testName.replaceAll("[^a-zA-Z0-9\\-]", "_")
-        + "_"
-        + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"))
-        + ".png";
   }
 
   @Override
@@ -53,7 +42,7 @@ public class ScreenshotListener implements ITestListener {
     }
 
     byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-    String filename = buildFileName(result.getName());
+    String filename = ScreenshotStore.buildFileName(result.getName());
     try {
       screenshotStore.storeScreenshot(screenshotBytes, filename);
     } catch (IOException e) {

--- a/src/test/java/com/automation/reporting/ScreenshotListener.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListener.java
@@ -41,11 +41,16 @@ public class ScreenshotListener implements ITestListener {
       return;
     }
 
-    byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+    if (!(driver instanceof TakesScreenshot takesScreenshot)) {
+      LOG.warn("Driver does not support screenshots");
+      return;
+    }
+
     String filename = ScreenshotStore.buildFileName(result.getName());
     try {
+      byte[] screenshotBytes = takesScreenshot.getScreenshotAs(OutputType.BYTES);
       screenshotStore.storeScreenshot(screenshotBytes, filename);
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
       LOG.error("Failed to save screenshot: {}", filename, e);
     }
   }

--- a/src/test/java/com/automation/reporting/ScreenshotListener.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListener.java
@@ -31,7 +31,7 @@ public class ScreenshotListener implements ITestListener {
 
   /** Builds filename for screenshot on failure */
   public static String buildFileName(String testName) {
-    return testName.replace(" ", "_")
+    return testName.replaceAll("[^a-zA-Z0-9\\-]", "_")
         + "_"
         + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"))
         + ".png";

--- a/src/test/java/com/automation/reporting/ScreenshotListener.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListener.java
@@ -33,7 +33,7 @@ public class ScreenshotListener implements ITestListener {
   public static String buildFileName(String testName) {
     return testName.replaceAll("[^a-zA-Z0-9\\-]", "_")
         + "_"
-        + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss"))
+        + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"))
         + ".png";
   }
 

--- a/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
@@ -1,10 +1,9 @@
 package com.automation.reporting;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for ScreenshotListenerTest */
+/** Unit tests for ScreenshotListener */
 public class ScreenshotListenerTest {
 
   @Test
@@ -14,7 +13,7 @@ public class ScreenshotListenerTest {
     assertThat(filename).startsWith("successfulLoginTest_");
     assertThat(filename).endsWith(".png");
     assertThat(filename)
-        .matches("successfulLoginTest_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.png");
+        .matches("successfulLoginTest_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}.png");
   }
 
   @Test

--- a/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
@@ -24,4 +24,12 @@ public class ScreenshotListenerTest {
     assertThat(filename).doesNotContain(" ");
     assertThat(filename).endsWith(".png");
   }
+
+  @Test
+  void shouldReplaceIllegalCharactersInFileName() {
+    String filename = ScreenshotListener.buildFileName("myTest[0](foo:bar)");
+    assertThat(filename).startsWith("myTest_0__foo_bar_");
+    assertThat(filename).endsWith(".png");
+    assertThat(filename).doesNotContain("[", "]", "(", ")", ":");
+  }
 }

--- a/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
@@ -1,6 +1,7 @@
 package com.automation.reporting;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.Test;
 
 /** Unit tests for ScreenshotListener */
@@ -9,7 +10,7 @@ public class ScreenshotListenerTest {
   @Test
   void shouldBuildFileName() {
     String testName = "successfulLoginTest";
-    String filename = ScreenshotListener.buildFileName(testName);
+    String filename = ScreenshotStore.buildFileName(testName);
     assertThat(filename).startsWith("successfulLoginTest_");
     assertThat(filename).endsWith(".png");
     assertThat(filename)
@@ -18,7 +19,7 @@ public class ScreenshotListenerTest {
 
   @Test
   void shouldReplaceSpacesInFileName() {
-    String filename = ScreenshotListener.buildFileName("Successful login");
+    String filename = ScreenshotStore.buildFileName("Successful login");
     assertThat(filename).startsWith("Successful_login_");
     assertThat(filename).doesNotContain(" ");
     assertThat(filename).endsWith(".png");
@@ -26,7 +27,7 @@ public class ScreenshotListenerTest {
 
   @Test
   void shouldReplaceIllegalCharactersInFileName() {
-    String filename = ScreenshotListener.buildFileName("myTest[0](foo:bar)");
+    String filename = ScreenshotStore.buildFileName("myTest[0](foo:bar)");
     assertThat(filename).startsWith("myTest_0__foo_bar_");
     assertThat(filename).endsWith(".png");
     assertThat(filename).doesNotContain("[", "]", "(", ")", ":");

--- a/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListenerTest.java
@@ -1,0 +1,27 @@
+package com.automation.reporting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for ScreenshotListenerTest */
+public class ScreenshotListenerTest {
+
+  @Test
+  void shouldBuildFileName() {
+    String testName = "successfulLoginTest";
+    String filename = ScreenshotListener.buildFileName(testName);
+    assertThat(filename).startsWith("successfulLoginTest_");
+    assertThat(filename).endsWith(".png");
+    assertThat(filename)
+        .matches("successfulLoginTest_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}\\.png");
+  }
+
+  @Test
+  void shouldReplaceSpacesInFileName() {
+    String filename = ScreenshotListener.buildFileName("Successful login");
+    assertThat(filename).startsWith("Successful_login_");
+    assertThat(filename).doesNotContain(" ");
+    assertThat(filename).endsWith(".png");
+  }
+}

--- a/src/test/java/com/automation/reporting/ScreenshotStore.java
+++ b/src/test/java/com/automation/reporting/ScreenshotStore.java
@@ -1,0 +1,16 @@
+package com.automation.reporting;
+
+import java.io.IOException;
+
+/** Interface to save screenshots of failed tests to file location */
+public interface ScreenshotStore {
+
+  /**
+   * Saves a screenshot to the configured storage destination.
+   *
+   * @param bytes the screenshot image data
+   * @param filename the name of the file to save
+   * @throws IOException if the screenshot cannot be saved
+   */
+  void storeScreenshot(byte[] bytes, String filename) throws IOException;
+}

--- a/src/test/java/com/automation/reporting/ScreenshotStore.java
+++ b/src/test/java/com/automation/reporting/ScreenshotStore.java
@@ -1,9 +1,19 @@
 package com.automation.reporting;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 /** Interface to save screenshots of failed tests to file location */
 public interface ScreenshotStore {
+
+  /** Builds filename for screenshot on failure */
+  static String buildFileName(String testName) {
+    return testName.replaceAll("[^a-zA-Z0-9\\-]", "_")
+        + "_"
+        + LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss-SSS"))
+        + ".png";
+  }
 
   /**
    * Saves a screenshot to the configured storage destination.

--- a/src/test/java/com/automation/reporting/ScreenshotStoreTest.java
+++ b/src/test/java/com/automation/reporting/ScreenshotStoreTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-/** Unit tests for ScreenshotListener */
-public class ScreenshotListenerTest {
+/** Unit tests for ScreenshotStore */
+public class ScreenshotStoreTest {
 
   @Test
   void shouldBuildFileName() {
@@ -14,7 +14,7 @@ public class ScreenshotListenerTest {
     assertThat(filename).startsWith("successfulLoginTest_");
     assertThat(filename).endsWith(".png");
     assertThat(filename)
-        .matches("successfulLoginTest_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}.png");
+        .matches("successfulLoginTest_\\d{4}-\\d{2}-\\d{2}_\\d{2}-\\d{2}-\\d{2}-\\d{3}\\.png");
   }
 
   @Test
@@ -27,9 +27,9 @@ public class ScreenshotListenerTest {
 
   @Test
   void shouldReplaceIllegalCharactersInFileName() {
-    String filename = ScreenshotStore.buildFileName("myTest[0](foo:bar)");
+    String filename = ScreenshotStore.buildFileName("myTest[0](foo:bar)/baz\\qux");
     assertThat(filename).startsWith("myTest_0__foo_bar_");
     assertThat(filename).endsWith(".png");
-    assertThat(filename).doesNotContain("[", "]", "(", ")", ":");
+    assertThat(filename).doesNotContain("[", "]", "(", ")", ":", "/", "\\");
   }
 }

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -2,13 +2,11 @@ package com.automation.stepdefinitions;
 
 import com.automation.base.BaseTest;
 import com.automation.reporting.LocalScreenshotStore;
-import com.automation.reporting.ScreenshotListener;
 import com.automation.reporting.ScreenshotStore;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 import java.io.IOException;
-import java.nio.file.Path;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
@@ -22,7 +20,7 @@ import org.slf4j.LoggerFactory;
 public class Hooks {
 
   private final ScreenshotStore screenshotStore =
-      new LocalScreenshotStore(Path.of("target/screenshots"));
+      new LocalScreenshotStore(LocalScreenshotStore.DEFAULT_DIR);
   private static final Logger LOG = LoggerFactory.getLogger(Hooks.class);
   private final BaseTest baseTest;
 
@@ -57,7 +55,7 @@ public class Hooks {
       return;
     }
     byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
-    String filename = ScreenshotListener.buildFileName(scenarioName);
+    String filename = ScreenshotStore.buildFileName(scenarioName);
     try {
       screenshotStore.storeScreenshot(screenshotBytes, filename);
     } catch (IOException e) {

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -1,9 +1,17 @@
 package com.automation.stepdefinitions;
 
 import com.automation.base.BaseTest;
+import com.automation.reporting.LocalScreenshotStore;
+import com.automation.reporting.ScreenshotListener;
+import com.automation.reporting.ScreenshotStore;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,8 +21,9 @@ import org.slf4j.LoggerFactory;
  */
 public class Hooks {
 
+  private final ScreenshotStore screenshotStore =
+      new LocalScreenshotStore(Path.of("target/screenshots"));
   private static final Logger LOG = LoggerFactory.getLogger(Hooks.class);
-
   private final BaseTest baseTest;
 
   public Hooks(BaseTest baseTest) {
@@ -28,13 +37,31 @@ public class Hooks {
     baseTest.setUp();
   }
 
-  /** Closes down driver once cucumber test has completed */
+  /** Takes screenshot on test failure and closes down driver once cucumber test has completed */
   @After
   public void tearDown(Scenario scenario) {
+    if (scenario.isFailed()) {
+      captureScreenshot(scenario.getName());
+    }
     try {
       baseTest.tearDown();
     } finally {
       LOG.info("Finished scenario: {}", scenario.getName());
+    }
+  }
+
+  private void captureScreenshot(String scenarioName) {
+    WebDriver driver = baseTest.getDriver();
+    if (driver == null) {
+      LOG.warn("Driver is null, skipping screenshot");
+      return;
+    }
+    byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+    String filename = ScreenshotListener.buildFileName(scenarioName);
+    try {
+      screenshotStore.storeScreenshot(screenshotBytes, filename);
+    } catch (IOException e) {
+      LOG.error("Failed to save screenshot: {}", filename, e);
     }
   }
 }

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -38,13 +38,18 @@ public class Hooks {
   /** Takes screenshot on test failure and closes down driver once cucumber test has completed */
   @After
   public void tearDown(Scenario scenario) {
-    if (scenario.isFailed()) {
-      captureScreenshot(scenario.getName());
-    }
     try {
-      baseTest.tearDown();
+      if (scenario.isFailed()) {
+        captureScreenshot(scenario.getName());
+      }
+    } catch (RuntimeException e) {
+      LOG.error("Failed to capture screenshot for scenario: {}", scenario.getName(), e);
     } finally {
-      LOG.info("Finished scenario: {}", scenario.getName());
+      try {
+        baseTest.tearDown();
+      } finally {
+        LOG.info("Finished scenario: {}", scenario.getName());
+      }
     }
   }
 
@@ -54,11 +59,15 @@ public class Hooks {
       LOG.warn("Driver is null, skipping screenshot");
       return;
     }
+    if (!(driver instanceof TakesScreenshot)) {
+      LOG.warn("Driver does not support screenshots, skipping screenshot");
+      return;
+    }
     byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
     String filename = ScreenshotStore.buildFileName(scenarioName);
     try {
       screenshotStore.storeScreenshot(screenshotBytes, filename);
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
       LOG.error("Failed to save screenshot: {}", filename, e);
     }
   }


### PR DESCRIPTION
## Summary
Adds screenshot capture on test failure so browser state at the failure point can be observed.

## Changes
- ScreenshotStore interface with pluggable design for future storage backends (e.g. S3)
- LocalScreenshotStore implementation saves to target/screenshots/
- ScreenshotListener captures screenshots on TestNG test failures
- Cucumber screenshot capture added to Hooks
- BaseTest annotated with @Listeners for automatic registration
- Unit tests for LocalScreenshotStore and ScreenshotListener filename building

## Testing
- Manually verified TestNG screenshot output by forcing a test failure
- Manually verified Cucumber screenshot output by forcing a scenario failure
- mvn verify: 15 unit tests (Surefire), 6 integration tests (Failsafe) — all green

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic screenshot capture on test failures for TestNG and Cucumber; listener/hook registration ensures screenshots are attempted on failure.

* **Security**
  * Local storage with path validation to prevent directory traversal and unauthorised filesystem access.

* **Behaviour**
  * Capture/storage errors are caught and logged so teardown continues and test flows aren’t blocked.

* **Tests**
  * New tests for filename generation, storage behaviour and traversal protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->