### PR TITLE
chore: set project.build.sourceEncoding to UTF-8, closes #44

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
## Summary
Set project.build.sourceEncoding to UTF-8 so that character encoding works as expected regardless of OS and locale

## Changes
- Added <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding> to properties in pom.xml

## Testing
- mvn verify: 17 unit tests (Surefire), 6 integration tests (Failsafe) — all green

Closes #44 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Maven build configuration for improved text encoding consistency during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->