### PR TITLE
Feature/27 add inventorypage with product and sorting tests

### DIFF
--- a/src/test/java/com/automation/pages/InventoryPage.java
+++ b/src/test/java/com/automation/pages/InventoryPage.java
@@ -1,0 +1,75 @@
+package com.automation.pages;
+
+import java.util.List;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.PageFactory;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Page object for the SauceDemo inventory page. */
+public class InventoryPage extends BasePage {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InventoryPage.class);
+
+  @FindBy(className = "product_sort_container")
+  private WebElement dropDown;
+
+  @FindBy(className = "inventory_item_name")
+  private List<WebElement> itemNameList;
+
+  @FindBy(className = "shopping_cart_badge")
+  private WebElement cartBadge;
+
+  public InventoryPage(WebDriver driver) {
+    super(driver);
+    PageFactory.initElements(driver, this);
+  }
+
+  /** Returns number of elements with the inventory item description classname */
+  public int getProductCount() {
+    LOG.debug("Getting element count for items");
+    wait.until(
+        ExpectedConditions.visibilityOfElementLocated(By.className("inventory_item_description")));
+    return getElementCount(By.className("inventory_item_description"));
+  }
+
+  /** Selects provided string from filter dropdown */
+  public void selectSortOption(String option) {
+    LOG.debug("Selecting filter dropdown option: {}", option);
+    selectDropdown(dropDown, option);
+  }
+
+  /** Gets name of first displayed item */
+  public String getFirstItemName() {
+    LOG.debug("Getting first item name");
+    wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("inventory_item_name")));
+    return itemNameList.get(0).getText();
+  }
+
+  /** Gets name of last displayed item */
+  public String getLastItemName() {
+    LOG.debug("Getting last item name");
+    return itemNameList.get(itemNameList.size() - 1).getText();
+  }
+
+  /** Clicks add to cart for the provided item name */
+  public void clickAddToCart(String itemName) {
+    LOG.debug("Clicking add to cart for item: {}", itemName);
+    String addToCartId = "add-to-cart-" + itemName.toLowerCase().replaceAll(" ", "-");
+    wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(addToCartId)));
+    driver.findElement(By.id(addToCartId)).click();
+  }
+
+  /** Gets the number of items in the cart */
+  public int getCartBadgeNumber() {
+    LOG.debug("Getting number on cart badge");
+    if (driver.findElements(By.className("shopping_cart_badge")).isEmpty()) {
+      return 0;
+    }
+    return Integer.parseInt(cartBadge.getText());
+  }
+}

--- a/src/test/java/com/automation/pages/InventoryPage.java
+++ b/src/test/java/com/automation/pages/InventoryPage.java
@@ -47,21 +47,27 @@ public class InventoryPage extends BasePage {
   public String getFirstItemName() {
     LOG.debug("Getting first item name");
     wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("inventory_item_name")));
+    if (itemNameList.isEmpty()) {
+      throw new IllegalStateException("No inventory items are displayed.");
+    }
     return itemNameList.get(0).getText();
   }
 
   /** Gets name of last displayed item */
   public String getLastItemName() {
     LOG.debug("Getting last item name");
+    wait.until(ExpectedConditions.visibilityOfElementLocated(By.className("inventory_item_name")));
+    if (itemNameList.isEmpty()) {
+      throw new IllegalStateException("No inventory items are displayed.");
+    }
     return itemNameList.get(itemNameList.size() - 1).getText();
   }
 
   /** Clicks add to cart for the provided item name */
   public void clickAddToCart(String itemName) {
     LOG.debug("Clicking add to cart for item: {}", itemName);
-    String addToCartId = "add-to-cart-" + itemName.toLowerCase().replaceAll(" ", "-");
-    wait.until(ExpectedConditions.visibilityOfElementLocated(By.id(addToCartId)));
-    driver.findElement(By.id(addToCartId)).click();
+    String addToCartId = "add-to-cart-" + itemName.toLowerCase().replace(" ", "-");
+    wait.until(ExpectedConditions.elementToBeClickable(By.id(addToCartId))).click();
   }
 
   /** Gets the number of items in the cart */

--- a/src/test/java/com/automation/runners/CucumberRunnerIT.java
+++ b/src/test/java/com/automation/runners/CucumberRunnerIT.java
@@ -4,12 +4,13 @@ import io.cucumber.testng.AbstractTestNGCucumberTests;
 import io.cucumber.testng.CucumberOptions;
 import org.testng.annotations.DataProvider;
 
+/** Cucumber TestNG runner for all feature files. */
 @CucumberOptions(
     features = "src/test/resources/features",
     glue = "com.automation.stepdefinitions",
     plugin = {"pretty", "html:target/cucumber-reports.html"},
     monochrome = true)
-public class LoginRunnerIT extends AbstractTestNGCucumberTests {
+public class CucumberRunnerIT extends AbstractTestNGCucumberTests {
 
   /** Provides Cucumber scenarios as a TestNG DataProvider with parallel execution enabled. */
   @Override

--- a/src/test/java/com/automation/stepdefinitions/CommonSteps.java
+++ b/src/test/java/com/automation/stepdefinitions/CommonSteps.java
@@ -1,0 +1,32 @@
+package com.automation.stepdefinitions;
+
+import com.automation.base.BaseTest;
+import com.automation.pages.LoginPage;
+import com.automation.utils.ConfigReader;
+import io.cucumber.java.en.Given;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Cucumber step definitions for common feature scenarios. */
+public class CommonSteps {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CommonSteps.class);
+  private final BaseTest baseTest;
+  private final ConfigReader config;
+
+  public CommonSteps(BaseTest baseTest) {
+    this.baseTest = baseTest;
+    this.config = baseTest.getConfigReader();
+  }
+
+  /** Logs into the saucedemo site with valid details */
+  @Given("the user is logged in")
+  public void theUserIsLoggedIn() {
+    String baseUrl = config.get("BASE_URL");
+    LOG.info("Navigating to base page. URL: {}", baseUrl);
+    baseTest.getDriver().get(baseUrl);
+    LoginPage loginPage = new LoginPage(baseTest.getDriver());
+    loginPage.login(config.get("STANDARD_USER"), config.get("PASSWORD"));
+    loginPage.waitForUrl(config.get("BASE_URL") + config.get("INVENTORY_PATH"));
+  }
+}

--- a/src/test/java/com/automation/stepdefinitions/InventorySteps.java
+++ b/src/test/java/com/automation/stepdefinitions/InventorySteps.java
@@ -6,8 +6,6 @@ import com.automation.base.BaseTest;
 import com.automation.pages.InventoryPage;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Cucumber step definitions for inventory feature scenarios. Maps Gherkin steps to actions on the
@@ -15,7 +13,6 @@ import org.slf4j.LoggerFactory;
  */
 public class InventorySteps {
 
-  private static final Logger LOG = LoggerFactory.getLogger(InventorySteps.class);
   private final BaseTest baseTest;
   private InventoryPage inventoryPage;
 
@@ -53,7 +50,7 @@ public class InventorySteps {
   /** Asserts the cart badge number is not zero */
   @Then("the cart badge displays the number of items in it")
   public void theCartBadgeDisplaysTheNumberOfItemsInIt() {
-    assertThat(getInventoryPage().getCartBadgeNumber()).isNotZero();
+    assertThat(getInventoryPage().getCartBadgeNumber()).isEqualTo(1);
   }
 
   private InventoryPage getInventoryPage() {

--- a/src/test/java/com/automation/stepdefinitions/InventorySteps.java
+++ b/src/test/java/com/automation/stepdefinitions/InventorySteps.java
@@ -1,0 +1,65 @@
+package com.automation.stepdefinitions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.automation.base.BaseTest;
+import com.automation.pages.InventoryPage;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cucumber step definitions for inventory feature scenarios. Maps Gherkin steps to actions on the
+ * InventoryPage.
+ */
+public class InventorySteps {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InventorySteps.class);
+  private final BaseTest baseTest;
+  private InventoryPage inventoryPage;
+
+  private static final String ADD_TO_CART_PRODUCT = "Sauce Labs Backpack";
+
+  public InventorySteps(BaseTest baseTest) {
+    this.baseTest = baseTest;
+  }
+
+  /** Selects the specified sort option from the filter dropdown. */
+  @When("the filter is changed to {string}")
+  public void theFilterIsChangedTo(String sortOption) {
+    getInventoryPage().selectSortOption(sortOption);
+  }
+
+  /** Clicks to add item to cart */
+  @When("an item is added to the Cart")
+  public void anItemIsAddedToTheCart() {
+    getInventoryPage().clickAddToCart(ADD_TO_CART_PRODUCT);
+  }
+
+  /** Asserts the number of products displayed is not zero */
+  @Then("a product is displayed")
+  public void aProductIsDisplayed() {
+    assertThat(getInventoryPage().getProductCount()).isNotZero();
+  }
+
+  /** Asserts the first and last item matches the input strings */
+  @Then("the first item is {string} and the last item is {string}")
+  public void theFirstItemIsAndTheLastItemIs(String firstItem, String lastItem) {
+    assertThat(getInventoryPage().getFirstItemName()).isEqualTo(firstItem);
+    assertThat(getInventoryPage().getLastItemName()).isEqualTo(lastItem);
+  }
+
+  /** Asserts the cart badge number is not zero */
+  @Then("the cart badge displays the number of items in it")
+  public void theCartBadgeDisplaysTheNumberOfItemsInIt() {
+    assertThat(getInventoryPage().getCartBadgeNumber()).isNotZero();
+  }
+
+  private InventoryPage getInventoryPage() {
+    if (inventoryPage == null) {
+      inventoryPage = new InventoryPage(baseTest.getDriver());
+    }
+    return inventoryPage;
+  }
+}

--- a/src/test/java/com/automation/testdata/InventoryScenario.java
+++ b/src/test/java/com/automation/testdata/InventoryScenario.java
@@ -1,0 +1,9 @@
+package com.automation.testdata;
+
+/** Test data record for inventory sort scenarios. */
+public record InventoryScenario(String sortOption, String firstItem, String lastItem) {
+  @Override
+  public String toString() {
+    return sortOption;
+  }
+}

--- a/src/test/java/com/automation/testdata/LoginScenario.java
+++ b/src/test/java/com/automation/testdata/LoginScenario.java
@@ -1,5 +1,6 @@
 package com.automation.testdata;
 
+/** Test data record for login scenarios. */
 public record LoginScenario(String name, String username, String password, String expectedError) {
   @Override
   public String toString() {

--- a/src/test/java/com/automation/tests/InventoryIT.java
+++ b/src/test/java/com/automation/tests/InventoryIT.java
@@ -35,7 +35,7 @@ public class InventoryIT extends BaseTest {
   @Test
   public void theCartBadgeDisplaysTheNumberOfItemsInIt() {
     inventoryPage.get().clickAddToCart(ADD_TO_CART_PRODUCT);
-    assertThat(inventoryPage.get().getCartBadgeNumber()).isNotZero();
+    assertThat(inventoryPage.get().getCartBadgeNumber()).isEqualTo(1);
   }
 
   @Test(dataProvider = "sortOptionsData")

--- a/src/test/java/com/automation/tests/InventoryIT.java
+++ b/src/test/java/com/automation/tests/InventoryIT.java
@@ -1,0 +1,74 @@
+package com.automation.tests;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.automation.base.BaseTest;
+import com.automation.pages.InventoryPage;
+import com.automation.pages.LoginPage;
+import com.automation.testdata.InventoryScenario;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** TestNG integration tests for the inventory page. */
+public class InventoryIT extends BaseTest {
+
+  private static final ThreadLocal<InventoryPage> inventoryPage = new ThreadLocal<>();
+  private static final String ADD_TO_CART_PRODUCT = "Sauce Labs Backpack";
+
+  @BeforeMethod
+  public void loginToSauceDemoSite() {
+    getDriver().get(getConfigReader().get("BASE_URL"));
+    LoginPage loginPage = new LoginPage(getDriver());
+    loginPage.login(getConfigReader().get("STANDARD_USER"), getConfigReader().get("PASSWORD"));
+    loginPage.waitForUrl(
+        getConfigReader().get("BASE_URL") + getConfigReader().get("INVENTORY_PATH"));
+    inventoryPage.set(new InventoryPage(getDriver()));
+  }
+
+  @Test
+  public void aProductIsDisplayed() {
+    assertThat(inventoryPage.get().getProductCount()).isNotZero();
+  }
+
+  @Test
+  public void theCartBadgeDisplaysTheNumberOfItemsInIt() {
+    inventoryPage.get().clickAddToCart(ADD_TO_CART_PRODUCT);
+    assertThat(inventoryPage.get().getCartBadgeNumber()).isNotZero();
+  }
+
+  @Test(dataProvider = "sortOptionsData")
+  public void sortInventoryTest(InventoryScenario inventoryScenario) {
+    inventoryPage.get().selectSortOption(inventoryScenario.sortOption());
+    assertThat(inventoryPage.get().getFirstItemName()).isEqualTo(inventoryScenario.firstItem());
+    assertThat(inventoryPage.get().getLastItemName()).isEqualTo(inventoryScenario.lastItem());
+  }
+
+  @DataProvider(name = "sortOptionsData")
+  public Object[][] sortOptionsData() {
+    return new Object[][] {
+      {
+        new InventoryScenario(
+            "Name (A to Z)", "Sauce Labs Backpack", "Test.allTheThings() T-Shirt (Red)")
+      },
+      {
+        new InventoryScenario(
+            "Name (Z to A)", "Test.allTheThings() T-Shirt (Red)", "Sauce Labs Backpack")
+      },
+      {
+        new InventoryScenario(
+            "Price (low to high)", "Sauce Labs Onesie", "Sauce Labs Fleece Jacket")
+      },
+      {
+        new InventoryScenario(
+            "Price (high to low)", "Sauce Labs Fleece Jacket", "Sauce Labs Onesie")
+      }
+    };
+  }
+
+  @AfterMethod(alwaysRun = true)
+  public void tearDownPage() {
+    inventoryPage.remove();
+  }
+}

--- a/src/test/resources/features/inventory.feature
+++ b/src/test/resources/features/inventory.feature
@@ -1,0 +1,22 @@
+Feature: Inventory page interactions
+
+    Scenario: Product is displayed
+        Given the user is logged in 
+        Then a product is displayed
+
+    Scenario Outline: Sorting products
+        Given the user is logged in
+        When the filter is changed to '<sort_option>'
+        Then the first item is '<first_item>' and the last item is '<last_item>'
+
+        Examples: 
+            | sort_option | first_item | last_item |
+            | Name (A to Z) | Sauce Labs Backpack | Test.allTheThings() T-Shirt (Red) |
+            | Name (Z to A) | Test.allTheThings() T-Shirt (Red) | Sauce Labs Backpack |
+            | Price (low to high) | Sauce Labs Onesie | Sauce Labs Fleece Jacket |
+            | Price (high to low) | Sauce Labs Fleece Jacket | Sauce Labs Onesie |
+
+    Scenario: Cart badge is updated
+        Given the user is logged in
+        When an item is added to the Cart
+        Then the cart badge displays the number of items in it

--- a/testng.xml
+++ b/testng.xml
@@ -6,10 +6,15 @@
             <class name="com.automation.tests.LoginIT"/>
         </classes>
     </test>
+    <test name="InventoryTests">
+        <classes>
+            <class name="com.automation.tests.InventoryIT"/>
+        </classes>
+    </test>
 
     <test name="CucumberTests">
         <classes>
-            <class name="com.automation.runners.LoginRunnerIT"/>
+            <class name="com.automation.runners.CucumberRunnerIT"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Summary
Added InventoryPage POM with product listing, sorting, and add-to-cart tests. Extracted CommonSteps for shared Cucumber login precondition. Renamed LoginRunnerIT to CucumberRunnerIT to reflect broader scope.

## Changes
- InventoryPage POM with sort, product count, add-to-cart, and cart badge methods
- InventoryScenario record for DataProvider sort test data
- inventory.feature with Scenario Outline for four sort directions
- InventorySteps with lazy InventoryPage initialisation
- CommonSteps for shared "user is logged in" Given step
- InventoryIT with DataProvider-driven sorting, product display, and cart badge tests
- CucumberRunnerIT renamed from LoginRunnerIT
- testng.xml updated with InventoryTests block

## Testing
- 17 unit tests passing (mvn test)
- 18 integration tests passing (mvn verify)
- All four sort directions verified (A-Z, Z-A, price low-high, price high-low)
- Product display and cart badge tests passing
- Parallel execution confirmed via logs

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated tests covering inventory page: product visibility, sorting behaviour, and cart badge updates.
  * Introduced shared login/setup steps for reuse across scenarios and a data-driven sorting suite.
  * Updated test suite configuration to include the new inventory tests and run feature scenarios in parallel where applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->