### PR TITLE
chore: add 15 min timeout to ci workflow refs #74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 jobs: 
   test: 
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
###Summary
Adds 15 minute timeout to CI workflow to guard against hanging tests. 

###Changes 
- `timeout-minutes: 15` added to `ci.yml`

###Testing 
`mvn verify`: 17 unit tests (Surefire), 28 integration tests (Failsafe) — all green

closes #74 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to enforce bounded test execution timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->