### PR TITLE
chore: cache maven dependencies in CI refs #45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: maven
       - name: Build and test
         run: mvn verify
         env:


### PR DESCRIPTION
### Summary
Updated CI to cache maven dependencies for faster runs

### Changes
- Added `cache: maven` to `setup-java@v4` in `ci.yml`

### Testing 
`mvn verify`: 17 unit tests (Surefire), 28 integration tests (Failsafe) — all green

closes #45 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised the continuous integration pipeline for faster build processing and improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->