### PR TITLE
chore: add readme badges for java version and license refs #70

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![CI](https://github.com/lukewalker85/automation-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/lukewalker85/automation-framework/actions)
+[![Java](https://img.shields.io/badge/Java-21-ED8B00?style=flat&logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/21/)
+[![License](https://img.shields.io/github/license/lukewalker85/automation-framework)](LICENSE)
 
 # Automation Framework
 


### PR DESCRIPTION
### Summary
Added badges to the `README.md` to display java version and license. 

### Changes
- Added license badge to `README.md`
- Added java version 21 badge to `README.md`

### Testing 
`mvn verify`: 17 unit tests (Surefire), 28 integration tests (Failsafe) — all green

closes #70

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with additional project badges for enhanced repository visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->