### PR TITLE
chore: move test credentials to environment variables refs #73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,8 @@ jobs:
       - name: Build and test
         run: mvn verify
         env:
+          STANDARD_USER: ${{ secrets.STANDARD_USER }}
+          LOCKED_OUT_USER: ${{ secrets.LOCKED_OUT_USER }}
+          PASSWORD: ${{ secrets.PASSWORD }}
+          INVALID_PASSWORD: ${{ secrets.INVALID_PASSWORD }}
           HEADLESS: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,32 @@ Thanks for your interest in contributing to the Automation Framework.
 2. Run `mvn verify` to confirm all tests pass
 3. Create a feature branch from `master`
 
+## Test Credentials
+
+Test credentials are not stored in the repository. Set these environment 
+variables before running tests:
+
+- `STANDARD_USER`
+- `LOCKED_OUT_USER`
+- `PASSWORD`
+- `INVALID_PASSWORD`
+
+> `INVALID_PASSWORD` must be a value that does not match `PASSWORD` to ensure negative login tests fail for the correct reason.
+
+Example (Git Bash):
+
+```bash
+STANDARD_USER=<value> LOCKED_OUT_USER=<value> PASSWORD=<value> INVALID_PASSWORD=<value> mvn verify
+```
+
+Values are available on the [SauceDemo](https://www.saucedemo.com/) login page.
+
+In CI, these are passed via GitHub Secrets.
+
 ## Running Tests
+
+> **Note:** Test credentials must be set as environment variables before 
+> running tests. See [Test Credentials](#test-credentials) above.
 
 ```bash
 # Unit tests only

--- a/README.md
+++ b/README.md
@@ -42,7 +42,18 @@ src/test/resources/
 └── testdata/         # Data-driven test data
 ```
 
+## Configuration
+
+Non-sensitive configuration lives in `src/test/resources/config.properties`. 
+Environment variables override file values for CI flexibility.
+
+Test credentials are managed via environment variables (GitHub Secrets in CI). 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup instructions.
+
 ## Running Tests
+
+> **Note:** Test credentials must be set before running tests. 
+> See [Configuration](#configuration) above.
 
 ```bash
 # Unit tests only
@@ -54,12 +65,6 @@ mvn verify
 # Specific browser
 BROWSER=chrome mvn verify
 ```
-
-## Configuration
-
-All environment configuration lives in `src/test/resources/config.properties`. Environment variables override file values for CI flexibility.
-
-> **Note:** In production, sensitive values such as passwords and URLs should be stored as environment variables or a secrets manager, never committed to Git.
 
 ## Logging
 

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -10,12 +10,10 @@ BASE_URL=https://www.saucedemo.com/
 INVENTORY_PATH=inventory.html
 
 # ── Test Users ─────────────────────────────────────
-STANDARD_USER=standard_user
-LOCKED_OUT_USER=locked_out_user
+# Test users are passed in using environment variables
 
 # ── Test User Credentials ────────────────────────────────────
-PASSWORD=secret_sauce
-INVALID_PASSWORD=wrong_password
+# Test user credentials are passed in using environment variables
 
 # ── Test User Info ────────────────────────────────────
 FIRST_NAME=First


### PR DESCRIPTION
### Summary
Sensitive credentials removed from the repository and are now required to be passed in. Updated CI to use GitHub secrets to store the credentials

### Changes
- Credentials removed from `config.properties`
- Added comments to  `config.properties` explaining these values come from environment variables
- Credentials added to GitHub secrets
- ` ci.yml` updated to pass secrets as env variables to the mvn verify step
- `README.md` and `CONTRIBUTING.md` Updated to explain how to run tests with variables.  

### Testing 
- `mvn verify`: 17 unit tests (Surefire), 28 integration tests (Failsafe) — all green
- Confirmed config override works by passing variables in before mvn verify after credentials removed from `config.properties`


closes #73


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Test Credentials section to CONTRIBUTING.md with environment variable setup instructions.
  * Updated README with new Configuration section detailing test credential management.

* **Tests**
  * Updated CI workflow to manage test credentials via environment variables.
  * Modified test configuration to use environment variables for test user credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->