### PR TITLE
feature/72-make-explicit-timeout-configurable

### DIFF
--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -21,6 +21,10 @@ public class BaseTest {
   private static final Logger LOG = LoggerFactory.getLogger(BaseTest.class);
   private final ConfigReader configReader = new ConfigReader("config.properties");
 
+  public BaseTest() {
+    applyTimeout();
+  }
+
   public WebDriver getDriver() {
     return driver.get();
   }
@@ -50,5 +54,24 @@ public class BaseTest {
     } finally {
       driver.remove();
     }
+  }
+
+  /** Sets system property timeoutSeconds */
+  private void applyTimeout() {
+    String timeoutSeconds = configReader.get("WAIT_TIMEOUT_SECONDS");
+    if (timeoutSeconds == null) {
+      timeoutSeconds = "10";
+    }
+    try {
+      int parsed = Integer.parseInt(timeoutSeconds);
+      if (parsed <= 0) {
+        throw new IllegalArgumentException(
+            "WAIT_TIMEOUT_SECONDS must be a positive integer, got: " + timeoutSeconds);
+      }
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "WAIT_TIMEOUT_SECONDS is not a valid integer: '" + timeoutSeconds + "'", e);
+    }
+    System.setProperty("timeoutSeconds", timeoutSeconds);
   }
 }

--- a/src/test/java/com/automation/pages/BasePage.java
+++ b/src/test/java/com/automation/pages/BasePage.java
@@ -24,7 +24,16 @@ public class BasePage {
 
   public BasePage(WebDriver driver) {
     this.driver = driver;
-    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    int timeoutSeconds;
+    try {
+      timeoutSeconds = Integer.parseInt(System.getProperty("timeoutSeconds", "10"));
+    } catch (NumberFormatException e) {
+      LOG.warn(
+          "Invalid timeoutSeconds system property '{}'; falling back to 10",
+          System.getProperty("timeoutSeconds"));
+      timeoutSeconds = 10;
+    }
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(timeoutSeconds));
   }
 
   /** Waits for the element to be clickable, then clicks it. */

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -22,3 +22,6 @@ POSTCODE=S1111
 
 # ── Log Level ─────────────────────────────────────
 LOG_LEVEL=INFO
+
+# ── Timeout configuration ─────────────────────────────────────
+WAIT_TIMEOUT_SECONDS=10


### PR DESCRIPTION
### Summary 
Browser timeout can now be set by updating `config.properties` or passing in a environment variable. 

### Changes 
- WAIT_TIMEOUT property added to config.properties. Default value of 10
- Updated wait in `BasePage`'s constructor to get seconds variable from `System.getProperty("timeoutSeconds", "10")`. Defaults to 10 as failsafe.
- Updated `BaseTest` to set system property `timeoutSeconds` in constructor. Sets from env vars if present if not sets from `config.properties`

### Testing 
- `mvn verify`: 17 unit tests (Surefire), 28 integration tests (Failsafe) — all green
- Confirmed timeout override works by passing variables in before mvn verify.
- 
### Design Decision
Timeout is set as a system property in `BaseTest` rather than passed through every page object constructor. This follows the existing pattern used for log level (`applyLogLevel`) and avoids modifying 15+ constructors and creation sites for a framework-level setting.

closes #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Test timeouts are now dynamically configurable rather than fixed at 10 seconds. Timeouts can be customised via configuration settings with a default fallback value, allowing teams to adjust wait durations based on environment-specific requirements and improve test reliability across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->