### PR TITLE
feature/5-add-allure-test-reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .idea/
 *.class
 .vscode/
+.allure/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,18 @@ LOG_LEVEL=DEBUG mvn verify
 
 Logs are written to both the console and `target/logs/`, rotating at 10 MB. Valid levels: `DEBUG`, `INFO`, `WARN`, `ERROR`. Default: `INFO`.
 
+## Reporting
+
+Allure generates interactive HTML test reports automatically during `mvn verify`. Reports include pass/fail results with screenshots captured on failure.
+
+Reports are written to `target/site/allure-maven-plugin/`. To view the report in a browser:
+
+```bash
+mvn allure:serve
+```
+
+This starts a temporary web server and opens the report automatically.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for branch naming, commit conventions, PR process, and code formatting requirements.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Logs are written to both the console and `target/logs/`, rotating at 10 MB. Vali
 
 ## Reporting
 
-Allure generates interactive HTML test reports automatically during `mvn verify`. Reports include pass/fail results with screenshots captured on failure.
+> **Note:** If the build fails before integration tests run (e.g. compilation error), the report will not be generated.
+
+Allure generates interactive HTML test reports during `mvn verify`, after all tests have executed. Reports include pass/fail results with screenshots captured on failure.
 
 Reports are written to `target/site/allure-maven-plugin/`. To view the report in a browser:
 

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         <artifactId>allure-maven</artifactId>
         <version>2.12.0</version>
         <configuration>
-          <reportVersion>2.27.0</reportVersion>
+          <reportVersion>2.30.0</reportVersion>
         </configuration>
         <executions>
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <allure.version>2.34.0</allure.version>
   </properties>
   <dependencies>
     <dependency>
@@ -39,6 +40,18 @@
       <groupId>io.cucumber</groupId>
       <artifactId>cucumber-testng</artifactId>
       <version>7.15.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.qameta.allure</groupId>
+      <artifactId>allure-cucumber7-jvm</artifactId>
+      <version>${allure.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.qameta.allure</groupId>
+      <artifactId>allure-testng</artifactId>
+      <version>${allure.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -141,6 +154,23 @@
               <goal>check</goal>
             </goals>
             <phase>validate</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.qameta.allure</groupId>
+        <artifactId>allure-maven</artifactId>
+        <version>2.12.0</version>
+        <configuration>
+          <reportVersion>2.27.0</reportVersion>
+        </configuration>
+        <executions>
+          <execution>
+            <id>allure-report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>post-integration-test</phase>
           </execution>
         </executions>
       </plugin>

--- a/src/test/java/com/automation/reporting/ScreenshotListener.java
+++ b/src/test/java/com/automation/reporting/ScreenshotListener.java
@@ -1,6 +1,8 @@
 package com.automation.reporting;
 
 import com.automation.base.BaseTest;
+import io.qameta.allure.Allure;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -47,8 +49,10 @@ public class ScreenshotListener implements ITestListener {
     }
 
     String filename = ScreenshotStore.buildFileName(result.getName());
+    byte[] screenshotBytes = takesScreenshot.getScreenshotAs(OutputType.BYTES);
+    Allure.addAttachment(
+        "Screenshot on failure", "image/png", new ByteArrayInputStream(screenshotBytes), ".png");
     try {
-      byte[] screenshotBytes = takesScreenshot.getScreenshotAs(OutputType.BYTES);
       screenshotStore.storeScreenshot(screenshotBytes, filename);
     } catch (IOException | RuntimeException e) {
       LOG.error("Failed to save screenshot: {}", filename, e);

--- a/src/test/java/com/automation/runners/CucumberRunnerIT.java
+++ b/src/test/java/com/automation/runners/CucumberRunnerIT.java
@@ -8,7 +8,11 @@ import org.testng.annotations.DataProvider;
 @CucumberOptions(
     features = "src/test/resources/features",
     glue = "com.automation.stepdefinitions",
-    plugin = {"pretty", "html:target/cucumber-reports.html"},
+    plugin = {
+      "pretty",
+      "html:target/cucumber-reports.html",
+      "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm"
+    },
     monochrome = true)
 public class CucumberRunnerIT extends AbstractTestNGCucumberTests {
 

--- a/src/test/java/com/automation/stepdefinitions/Hooks.java
+++ b/src/test/java/com/automation/stepdefinitions/Hooks.java
@@ -6,6 +6,8 @@ import com.automation.reporting.ScreenshotStore;
 import io.cucumber.java.After;
 import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
+import io.qameta.allure.Allure;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -64,6 +66,8 @@ public class Hooks {
       return;
     }
     byte[] screenshotBytes = ((TakesScreenshot) driver).getScreenshotAs(OutputType.BYTES);
+    Allure.addAttachment(
+        "Screenshot on failure", "image/png", new ByteArrayInputStream(screenshotBytes), ".png");
     String filename = ScreenshotStore.buildFileName(scenarioName);
     try {
       screenshotStore.storeScreenshot(screenshotBytes, filename);

--- a/src/test/resources/allure.properties
+++ b/src/test/resources/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=target/allure-results


### PR DESCRIPTION
### Summary 
Allure reporting added. Reports are generated after each test run. Screenshots are captured on failure.

### Changes 
- `allure-cucumber7-jvm` and `allure-testng` dependencies added to `pom.xml`
- `allure-maven` plugin added to `pom.xml` runs in post-integration-test phase. 
- Added `"io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm"` to `CucumberRunnerIT`'s plugin options.
- Added Allure.addAttachment() to `Hooks.java` and `ScreenshotListener.java` to attach screenshots on failure to report 
- Added reporting section to `README.md` advising how to generate and view the reports. 
- Added `allure.properties` file to set report locataion "target/allure-results"
- Updated `.gitignore` to ignore ".allure/"

### Testing 
- `mvn verify`: 17 unit tests (Surefire), 28 integration tests (Failsafe) — all green
- Confirmed reports generated after successful run
- Confirmed screenshots are captured by passing in incorrect environment properties. 

closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated Allure test reporting to automatically capture and attach screenshots when test failures occur, providing enhanced visibility into test execution results.

* **Documentation**
  * Added reporting section with instructions for generating test reports during verification and previewing results via command-line interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->