### PR TITLE
feature/34-add-api-test-utilities-and-request-specification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,6 @@ jobs:
           LOCKED_OUT_USER: ${{ secrets.LOCKED_OUT_USER }}
           PASSWORD: ${{ secrets.PASSWORD }}
           INVALID_PASSWORD: ${{ secrets.INVALID_PASSWORD }}
+          API_USERNAME: ${{ secrets.API_USERNAME }}
+          API_PASSWORD: ${{ secrets.API_PASSWORD }}
           HEADLESS: true

--- a/src/test/java/com/automation/api/AuthTokenManager.java
+++ b/src/test/java/com/automation/api/AuthTokenManager.java
@@ -1,0 +1,38 @@
+package com.automation.api;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Manages Auth Tokens */
+public class AuthTokenManager {
+
+  private AuthTokenManager() {
+    // Utility class - prevent instantiation
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthTokenManager.class);
+
+  /** Gets auth token using spec from RequestSpecificationFactory */
+  public static String getAuthToken(String username, String password, RequestSpecification spec) {
+    if (username == null
+        || password == null
+        || spec == null
+        || username.isEmpty()
+        || password.isEmpty()) {
+      throw new IllegalArgumentException("username, password or spec cannot be null");
+    }
+    LOG.info("Retrieving auth token");
+    return RestAssured.given()
+        .spec(spec)
+        .body(Map.of("username", username, "password", password))
+        .when()
+        .post("/auth")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("token");
+  }
+}

--- a/src/test/java/com/automation/api/AuthTokenManagerTest.java
+++ b/src/test/java/com/automation/api/AuthTokenManagerTest.java
@@ -1,0 +1,29 @@
+package com.automation.api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for AuthTokenManager */
+class AuthTokenManagerTest {
+
+  @Test
+  void shouldThrowIllegalArgumentExceptionIfUsernameIsNull() {
+    assertThatThrownBy(
+            () ->
+                AuthTokenManager.getAuthToken(
+                    null,
+                    "test",
+                    RequestSpecificationFactory.buildRequestSpec("https://example.com")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowIllegalArgumentExceptionIfUsernameIsEmpty() {
+    assertThatThrownBy(
+            () ->
+                AuthTokenManager.getAuthToken(
+                    "", "", RequestSpecificationFactory.buildRequestSpec("https://example.com")))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/com/automation/api/RequestSpecificationFactory.java
+++ b/src/test/java/com/automation/api/RequestSpecificationFactory.java
@@ -1,0 +1,29 @@
+package com.automation.api;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.specification.RequestSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Creates Request Specification for APIs */
+public class RequestSpecificationFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestSpecificationFactory.class);
+
+  private RequestSpecificationFactory() {
+    // Utility class - prevent instantiation
+  }
+
+  /** Builds a Request Specification that contains a base URI, content type and accepts */
+  public static RequestSpecification buildRequestSpec(String baseUri) {
+    if (baseUri == null || baseUri.isEmpty()) {
+      throw new IllegalArgumentException("baseUri path cannot be null or empty");
+    }
+    LOG.info("Creating Request Specification, URI: {}", baseUri);
+    return RestAssured.given()
+        .baseUri(baseUri)
+        .contentType(ContentType.JSON)
+        .accept(ContentType.JSON);
+  }
+}

--- a/src/test/java/com/automation/api/RequestSpecificationFactoryTest.java
+++ b/src/test/java/com/automation/api/RequestSpecificationFactoryTest.java
@@ -1,0 +1,49 @@
+package com.automation.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.restassured.specification.QueryableRequestSpecification;
+import io.restassured.specification.RequestSpecification;
+import io.restassured.specification.SpecificationQuerier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for RequestSpecificationFactory */
+class RequestSpecificationFactoryTest {
+
+  private QueryableRequestSpecification queryable;
+
+  @BeforeEach
+  void setQueryableRequestSpecification() {
+    RequestSpecification spec = RequestSpecificationFactory.buildRequestSpec("https://example.com");
+    queryable = SpecificationQuerier.query(spec);
+  }
+
+  @Test
+  void shouldSetBaseUri() {
+    assertThat(queryable.getBaseUri()).isEqualTo("https://example.com");
+  }
+
+  @Test
+  void shouldSetContentType() {
+    assertThat(queryable.getContentType()).isEqualTo("application/json");
+  }
+
+  @Test
+  void shouldSetAcceptType() {
+    assertThat(queryable.getHeaders().getValue("Accept")).contains("application/json");
+  }
+
+  @Test
+  void shouldThrowIllegalArgumentExceptionIfBaseUriIsNull() {
+    assertThatThrownBy(() -> RequestSpecificationFactory.buildRequestSpec(null))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowIllegalArgumentExceptionIfBaseUriIsEmpty() {
+    assertThatThrownBy(() -> RequestSpecificationFactory.buildRequestSpec(""))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/src/test/java/com/automation/api/ResponseSpecificationFactory.java
+++ b/src/test/java/com/automation/api/ResponseSpecificationFactory.java
@@ -1,0 +1,25 @@
+package com.automation.api;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.specification.ResponseSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Creates Response Specification for APIs */
+public class ResponseSpecificationFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ResponseSpecificationFactory.class);
+
+  private ResponseSpecificationFactory() {
+    // Utility class - prevent instantiation
+  }
+
+  /** Builds a Response Specification that contains a response code and content type */
+  public static ResponseSpecification buildResponseSpec(int responseCode) {
+    LOG.info("Creating Response Specification, response code: {}", responseCode);
+    ResponseSpecification spec =
+        RestAssured.expect().statusCode(responseCode).contentType(ContentType.JSON);
+    return spec;
+  }
+}

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -8,12 +8,16 @@ HEADLESS=false
 # ── Application URLs ───────────────────────────────
 BASE_URL=https://www.saucedemo.com/
 INVENTORY_PATH=inventory.html
+BASE_API_URI=https://restful-booker.herokuapp.com
 
 # ── Test Users ─────────────────────────────────────
 # Test users are passed in using environment variables
 
 # ── Test User Credentials ────────────────────────────────────
 # Test user credentials are passed in using environment variables
+
+# ── API User Credentials ────────────────────────────────────
+# API user credentials are passed in using environment variables
 
 # ── Test User Info ────────────────────────────────────
 FIRST_NAME=First


### PR DESCRIPTION
### Summary
Added reusable API test utilities for request, response specifications and auth tokens.

## Changes  
- Added `RequestSpecificationFactoryTest.java` to test that base uri, content type and accept type are set. Also tests uri cannot be null or empty.
- Added `AuthTokenManagerTest.java` to test that arguments cannot be null or empty. 
- Added `RequestSpecificationFactory.java` to build request spec.
- Added `ResponseSpecificationFactory.java` to build response spec.
- Added `AuthTokenManager.java` to retrieve auth token.
- Updated `ci.yml` to contain api auth credentials (Credentials added to GitHub secrets).
- Updated `config.properties` with comment about where api credentials are stored. 

### Testing 
- `mvn verify`: 24 unit tests (Surefire), 28 integration tests (Failsafe) — all green
-  7 new unit tests in `RequestSpecificationFactoryTest.java`

closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added API authentication token retrieval utilities with comprehensive validation tests.
  * Added request and response specification factories for enhanced API testing.

* **Chores**
  * Updated CI workflow with API authentication environment variables.
  * Extended configuration with API base URI settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->