### PR TITLE
feature\3-wiremock-iam-api-mocking

### DIFF
--- a/src/test/java/com/automation/api/AuthTest.java
+++ b/src/test/java/com/automation/api/AuthTest.java
@@ -1,0 +1,66 @@
+package com.automation.api;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.automation.base.BaseApiTest;
+import io.restassured.RestAssured;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Tests for Auth */
+class AuthTest extends BaseApiTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuthTest.class);
+
+  @Test
+  void shouldReturnTokenForValidCredentials() {
+    LOG.info("Testing login with valid credentials");
+    getMockServer()
+        .stubFor(
+            post(urlEqualTo("/auth/login"))
+                .withRequestBody(
+                    equalToJson("{\"username\":\"validUser\",\"password\":\"validPass\"}"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"token\": \"abc123\"}")));
+
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .body(Map.of("username", "validUser", "password", "validPass"))
+        .when()
+        .post("/auth/login")
+        .then()
+        .statusCode(200)
+        .contentType("application/json")
+        .body("token", equalTo("abc123"));
+  }
+
+  @Test
+  void shouldReturn401ForInvalidCredentials() {
+    LOG.info("Testing login with invalid credentials");
+    getMockServer()
+        .stubFor(
+            post(urlEqualTo("/auth/login"))
+                .withRequestBody(containing("wrongUser"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(401)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\": \"Invalid credentials\"}")));
+
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .body(Map.of("username", "wrongUser", "password", "validPass"))
+        .when()
+        .post("/auth/login")
+        .then()
+        .statusCode(401)
+        .contentType("application/json")
+        .body("error", equalTo("Invalid credentials"));
+  }
+}

--- a/src/test/java/com/automation/api/UserOperationsTest.java
+++ b/src/test/java/com/automation/api/UserOperationsTest.java
@@ -1,0 +1,105 @@
+package com.automation.api;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+import com.automation.base.BaseApiTest;
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Tests for User Operations */
+class UserOperationsTest extends BaseApiTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(UserOperationsTest.class);
+
+  @Test
+  void shouldReturnUserDetailsForValidToken() {
+    LOG.info("Getting User details with valid token");
+    getMockServer()
+        .stubFor(
+            get(urlEqualTo("/users/1"))
+                .withHeader("Authorization", equalTo("Bearer abc123"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"id\": 1, \"name\": \"John Doe\"}")));
+
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .header("Authorization", "Bearer abc123")
+        .when()
+        .get("/users/1")
+        .then()
+        .statusCode(200)
+        .contentType("application/json")
+        .body("name", Matchers.equalTo("John Doe"))
+        .body("id", Matchers.equalTo(1));
+  }
+
+  @Test
+  void shouldReturn403WhenTokenMissing() {
+    LOG.info("Getting User details with missing token");
+    getMockServer()
+        .stubFor(
+            get(urlEqualTo("/users/1"))
+                .withHeader("Authorization", absent())
+                .willReturn(
+                    aResponse()
+                        .withStatus(403)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\": \"Forbidden\"}")));
+
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get("/users/1")
+        .then()
+        .statusCode(403)
+        .contentType("application/json")
+        .body("error", Matchers.equalTo("Forbidden"));
+  }
+
+  @Test
+  void shouldReturn204ForAuthorisedDelete() {
+    LOG.info("Deleting User with valid token");
+    getMockServer()
+        .stubFor(
+            delete(urlEqualTo("/users/1"))
+                .withHeader("Authorization", equalTo("Bearer abc123"))
+                .willReturn(aResponse().withStatus(204)));
+
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .header("Authorization", "Bearer abc123")
+        .when()
+        .delete("/users/1")
+        .then()
+        .statusCode(204);
+  }
+
+  @Test
+  void shouldReturn403ForUnauthorisedDelete() {
+    LOG.info("Deleting User with missing token");
+    getMockServer()
+        .stubFor(
+            delete(urlEqualTo("/users/1"))
+                .withHeader("Authorization", absent())
+                .willReturn(
+                    aResponse()
+                        .withStatus(403)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"error\": \"Forbidden\"}")));
+
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .delete("/users/1")
+        .then()
+        .statusCode(403)
+        .contentType("application/json")
+        .body("error", Matchers.equalTo("Forbidden"));
+  }
+}

--- a/src/test/java/com/automation/base/BaseApiTest.java
+++ b/src/test/java/com/automation/base/BaseApiTest.java
@@ -1,0 +1,53 @@
+package com.automation.base;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+
+import com.automation.api.RequestSpecificationFactory;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Base class for all mocked api test classes. Manages the Wiremock server lifecycle */
+public class BaseApiTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseApiTest.class);
+
+  private static WireMockServer wireMockServer;
+  private static RequestSpecification spec;
+
+  protected WireMockServer getMockServer() {
+    return wireMockServer;
+  }
+
+  protected RequestSpecification getRequestSpecification() {
+    return spec;
+  }
+
+  /** Sets up Wiremock server and RequestSpecification using servers baseUrl before all tests */
+  @BeforeAll
+  static void setUp() {
+    LOG.info("Starting Wiremock server");
+    wireMockServer = new WireMockServer(wireMockConfig().dynamicPort());
+    wireMockServer.start();
+    spec = RequestSpecificationFactory.buildRequestSpec(wireMockServer.baseUrl());
+  }
+
+  /** Clears stubs before each test */
+  @BeforeEach
+  void clearStubs() {
+    wireMockServer.resetAll();
+  }
+
+  /** Stops Wiremock server once all tests are complete */
+  @AfterAll
+  static void tearDown() {
+    if (wireMockServer != null) {
+      LOG.info("Stopping Wiremock server");
+      wireMockServer.stop();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds a mocked IAM API using WireMock with REST Assured tests, demonstrating API test automation against realistic endpoints without external dependencies.

## Changes
- `BaseApiTest` manages WireMock server lifecycle (dynamic port, stub reset, start/stop)
- `AuthTest` validates POST /auth/login for valid credentials (200 + token) and invalid credentials (401)
- `UserOperationsTest` validates GET /users/{id} and DELETE /users/{id} for authorised (200/204) and unauthorised (403) requests
- All tests assert status codes, response bodies, and content type headers
- Tests run via `mvn test` (Surefire/JUnit 5) as they are self-contained with no external dependencies

## Testing
- All 30 unit tests pass via mvn test
- Full suite passes via mvn verify (30 unit + 28 integration)
- WireMock server starts on dynamic port to avoid port conflicts

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Added automated test cases for authentication endpoints, validating successful login responses and error handling for invalid credentials
* Added automated test cases for user operation endpoints, covering data retrieval and deletion with valid and invalid authorisation
* Added base testing framework to support API integration testing with mock server and request specification utilities

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukewalker85/automation-framework/pull/97)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->