### PR TITLE
feature/32-add-rest-assured-tests-against-public-api

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,16 +23,19 @@ variables before running tests:
 - `LOCKED_OUT_USER`
 - `PASSWORD`
 - `INVALID_PASSWORD`
+- `API_USERNAME`
+- `API_PASSWORD`
 
 > `INVALID_PASSWORD` must be a value that does not match `PASSWORD` to ensure negative login tests fail for the correct reason.
 
 Example (Git Bash):
 
 ```bash
-STANDARD_USER=<value> LOCKED_OUT_USER=<value> PASSWORD=<value> INVALID_PASSWORD=<value> mvn verify
+STANDARD_USER=<value> LOCKED_OUT_USER=<value> PASSWORD=<value> INVALID_PASSWORD=<value> API_USERNAME=<value> API_PASSWORD=<value> mvn verify
 ```
 
-Values are available on the [SauceDemo](https://www.saucedemo.com/) login page.
+API username and password are available on the [restful-booker](https://restful-booker.herokuapp.com/apidoc/index.html#api-Auth-CreateToken) help page.
+Other values are available on the [SauceDemo](https://www.saucedemo.com/) login page.
 
 In CI, these are passed via GitHub Secrets.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A scalable test automation framework built from scratch using Java and Selenium 
 ```text
 src/test/java/com/automation/
 ├── api/              # REST Assured API tests
-├── base/             # BaseTest — driver lifecycle management
+├── base/             # Base test classes (driver, WireMock, live API)
 ├── pages/            # Page Object Model classes
 ├── reporting/        # Screenshot capture and storage
 ├── runners/          # Cucumber test runners
@@ -107,7 +107,7 @@ This project is licensed under the MIT License — see [LICENSE](LICENSE) for de
 - [x] Headless browser mode
 - [x] GitHub Actions workflow
 - [x] AI code reviews on pull requests
-- [ ] Allure test reporting
+- [x] Allure test reporting
 - [ ] REST Assured + WireMock API testing
 - [ ] CartPage and cart tests
 - [ ] CheckoutPage and end-to-end checkout tests

--- a/src/test/java/com/automation/api/BookingApiIT.java
+++ b/src/test/java/com/automation/api/BookingApiIT.java
@@ -71,7 +71,7 @@ public class BookingApiIT extends BaseLiveApiTest {
   public void shouldUpdateBookingDetails() {
     int id = createBooking();
     String token = getAuthToken();
-    LOG.info("Updating booking id: {} token: {}", id, token);
+    LOG.info("Updating booking id: {}", id);
     RestAssured.given()
         .spec(getRequestSpecification())
         .cookie("token", token)
@@ -88,7 +88,7 @@ public class BookingApiIT extends BaseLiveApiTest {
   public void shouldReturn404WhenCheckingDeletedBooking() {
     int id = createBooking();
     String token = getAuthToken();
-    LOG.info("Deleting booking id: {} token: {}", id, token);
+    LOG.info("Deleting booking id: {}", id);
     RestAssured.given()
         .spec(getRequestSpecification())
         .cookie("token", token)

--- a/src/test/java/com/automation/api/BookingApiIT.java
+++ b/src/test/java/com/automation/api/BookingApiIT.java
@@ -1,0 +1,171 @@
+package com.automation.api;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+import com.automation.base.BaseLiveApiTest;
+import io.restassured.RestAssured;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+/** TestNG integration tests for booking api */
+public class BookingApiIT extends BaseLiveApiTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BookingApiIT.class);
+
+  @Test
+  public void shouldReturnTokenForValidCredentials() {
+    LOG.info("Requesting token with valid credentials");
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .body(
+            Map.of(
+                "username",
+                getConfigReader().get("API_USERNAME"),
+                "password",
+                getConfigReader().get("API_PASSWORD")))
+        .when()
+        .post("/auth")
+        .then()
+        .statusCode(200)
+        .body("token", is(notNullValue()));
+  }
+
+  @Test
+  public void shouldReturnBookingId() {
+    LOG.info("Creating booking");
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .body(buildBookingBody())
+        .when()
+        .post("/booking")
+        .then()
+        .statusCode(200)
+        .body("bookingid", is(notNullValue()))
+        .body("booking.firstname", equalTo("Jim"));
+  }
+
+  @Test
+  public void shouldReturnBookingDetails() {
+    int id = createBooking();
+    LOG.info("Getting booking details from booking id: {}", id);
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get("/booking/" + id)
+        .then()
+        .statusCode(200)
+        .body("firstname", equalTo("Jim"))
+        .body("lastname", equalTo("Brown"))
+        .body("totalprice", equalTo(111))
+        .body("depositpaid", equalTo(true))
+        .body("bookingdates.checkin", equalTo("2018-01-01"))
+        .body("bookingdates.checkout", equalTo("2019-01-01"))
+        .body("additionalneeds", equalTo("Breakfast"));
+  }
+
+  @Test
+  public void shouldUpdateBookingDetails() {
+    int id = createBooking();
+    String token = getAuthToken();
+    LOG.info("Updating booking id: {} token: {}", id, token);
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .cookie("token", token)
+        .body(buildUpdatedBookingBody())
+        .when()
+        .put("/booking/" + id)
+        .then()
+        .statusCode(200)
+        .body("firstname", equalTo("Bob"))
+        .body("additionalneeds", equalTo("No Breakfast"));
+  }
+
+  @Test
+  public void shouldReturn404WhenCheckingDeletedBooking() {
+    int id = createBooking();
+    String token = getAuthToken();
+    LOG.info("Deleting booking id: {} token: {}", id, token);
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .cookie("token", token)
+        .when()
+        .delete("/booking/" + id)
+        .then()
+        .statusCode(201);
+
+    LOG.info("Booking deleted attempting to get details");
+    RestAssured.given()
+        .spec(getRequestSpecification())
+        .when()
+        .get("/booking/" + id)
+        .then()
+        .statusCode(404);
+  }
+
+  private Map<String, Object> buildBookingBody() {
+    return Map.of(
+        "firstname",
+        "Jim",
+        "lastname",
+        "Brown",
+        "totalprice",
+        111,
+        "depositpaid",
+        true,
+        "bookingdates",
+        Map.of("checkin", "2018-01-01", "checkout", "2019-01-01"),
+        "additionalneeds",
+        "Breakfast");
+  }
+
+  private int createBooking() {
+    LOG.info("Creating booking required for test");
+    return RestAssured.given()
+        .spec(getRequestSpecification())
+        .body(buildBookingBody())
+        .when()
+        .post("/booking")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("bookingid");
+  }
+
+  private String getAuthToken() {
+    LOG.info("Getting auth token required for test");
+    return RestAssured.given()
+        .spec(getRequestSpecification())
+        .body(
+            Map.of(
+                "username",
+                getConfigReader().get("API_USERNAME"),
+                "password",
+                getConfigReader().get("API_PASSWORD")))
+        .when()
+        .post("/auth")
+        .then()
+        .statusCode(200)
+        .extract()
+        .path("token");
+  }
+
+  private Map<String, Object> buildUpdatedBookingBody() {
+    return Map.of(
+        "firstname",
+        "Bob",
+        "lastname",
+        "Brown",
+        "totalprice",
+        111,
+        "depositpaid",
+        true,
+        "bookingdates",
+        Map.of("checkin", "2018-01-01", "checkout", "2019-01-01"),
+        "additionalneeds",
+        "No Breakfast");
+  }
+}

--- a/src/test/java/com/automation/base/BaseLiveApiTest.java
+++ b/src/test/java/com/automation/base/BaseLiveApiTest.java
@@ -27,16 +27,17 @@ public class BaseLiveApiTest {
 
   /**
    * Sets up RequestSpecification using the base URI from config. Overrides the Accept header as
-   * restful-booker requires an explicit content type. Overrides filters to use request and response
-   * logging filters
+   * restful-booker requires an explicit content type. Adds request and response logging filters
+   * when LOG_LEVEL is set to DEBUG.
    */
   @BeforeClass
   public void setup() {
     LOG.info("Creating RequestSpecification");
     spec =
         RequestSpecificationFactory.buildRequestSpec(configReader.get("BASE_API_URI"))
-            .accept("application/json")
-            .filter(new RequestLoggingFilter())
-            .filter(new ResponseLoggingFilter());
+            .accept("application/json");
+    if ("DEBUG".equals(configReader.get("LOG_LEVEL"))) {
+      spec = spec.filter(new RequestLoggingFilter()).filter(new ResponseLoggingFilter());
+    }
   }
 }

--- a/src/test/java/com/automation/base/BaseLiveApiTest.java
+++ b/src/test/java/com/automation/base/BaseLiveApiTest.java
@@ -1,0 +1,42 @@
+package com.automation.base;
+
+import com.automation.api.RequestSpecificationFactory;
+import com.automation.utils.ConfigReader;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
+import io.restassured.specification.RequestSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.BeforeClass;
+
+/** Base class for all live api test classes. */
+public class BaseLiveApiTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BaseLiveApiTest.class);
+  private final ConfigReader configReader = new ConfigReader("config.properties");
+
+  private RequestSpecification spec;
+
+  protected RequestSpecification getRequestSpecification() {
+    return spec;
+  }
+
+  protected ConfigReader getConfigReader() {
+    return configReader;
+  }
+
+  /**
+   * Sets up RequestSpecification using the base URI from config. Overrides the Accept header as
+   * restful-booker requires an explicit content type. Overrides filters to use request and response
+   * logging filters
+   */
+  @BeforeClass
+  public void setup() {
+    LOG.info("Creating RequestSpecification");
+    spec =
+        RequestSpecificationFactory.buildRequestSpec(configReader.get("BASE_API_URI"))
+            .accept("application/json")
+            .filter(new RequestLoggingFilter())
+            .filter(new ResponseLoggingFilter());
+  }
+}

--- a/testng.xml
+++ b/testng.xml
@@ -11,6 +11,11 @@
             <class name="com.automation.tests.InventoryIT"/>
         </classes>
     </test>
+    <test name="BookingApiTests">
+        <classes>
+            <class name="com.automation.api.BookingApiIT"/>
+        </classes>
+    </test>
 
     <test name="CucumberTests">
         <classes>


### PR DESCRIPTION
## Summary
Added REST Assured integration tests against the live restful-booker API, covering full CRUD operations and authentication. Introduced BaseLiveApiTest as a dedicated base class for live API tests, keeping WireMock and live API concerns separate.

## Changes
- Added `BaseLiveApiTest` with RequestSpecification setup, Accept header override, and request/response logging filters
- Added `BookingApiIT` with five independent tests: auth token creation, booking creation, retrieval, update, and deletion
- Added `BookingApiIT` to `testng.xml` as a new test suite
- Updated `CONTRIBUTING.md` with `API_USERNAME` and `API_PASSWORD` environment variables
- Updated `README` project structure and roadmap

## Testing
- All 5 new integration tests pass via `mvn verify`
- All 30 existing unit tests pass via `mvn test`
- All 33 integration tests pass via `mvn verify` (28 existing + 5 new)
- Tests run in parallel and are fully independent — each creates its own test data

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated contributor guidelines with API authentication credentials requirements
  * Clarified project structure documentation regarding base test classes and their capabilities
  * Marked Allure test reporting as completed in the roadmap

* **Tests**
  * Added comprehensive API integration tests covering authentication, booking creation, retrieval, updates, and deletion with proper assertion coverage
  * Introduced infrastructure for live API testing support

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lukewalker85/automation-framework/pull/98)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->