### PR TITLE
feat: add smoke and regression test groups refs #15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,10 +39,18 @@ Other values are available on the [SauceDemo](https://www.saucedemo.com/) login 
 
 In CI, these are passed via GitHub Secrets.
 
+## Configuration
+
+Non-sensitive configuration lives in `src/test/resources/config.properties`. 
+Environment variables override file values for CI flexibility.
+
+Test credentials are managed via environment variables (GitHub Secrets in CI). 
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup instructions.
+
 ## Running Tests
 
-> **Note:** Test credentials must be set as environment variables before 
-> running tests. See [Test Credentials](#test-credentials) above.
+> **Note:** Test credentials must be set before running tests. 
+> See [Configuration](#configuration) above.
 
 ```bash
 # Unit tests only
@@ -51,9 +59,17 @@ mvn test
 # Full suite (unit + integration)
 mvn verify
 
+# Smoke suite (fast, critical-path subset)
+mvn verify -Psmoke
+
+# Regression suite (full coverage, includes smoke)
+mvn verify -Pregression
+
 # Specific browser
 BROWSER=chrome mvn verify
 ```
+
+Smoke and regression suites each write their Allure results to a dedicated subfolder (`target/allure-results/smoke` / `target/allure-results/regression`), so results from one suite never overwrite or mix with another. Run `mvn allure:serve` with the matching profile (e.g. `mvn allure:serve -Psmoke`) to inspect that suite's results.
 
 ## Branch Naming
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ src/test/java/com/automation/
 src/test/resources/
 ├── features/         # Cucumber BDD feature files
 └── testdata/         # Data-driven test data
+testng.xml                  # Full suite (unit + integration)
+testng-smoke.xml            # Smoke suite (critical-path subset)
+testng-regression.xml       # Regression suite (full coverage)
 ```
 
 ## Configuration
@@ -62,9 +65,17 @@ mvn test
 # Full suite (unit + integration)
 mvn verify
 
+# Smoke suite (fast, critical-path subset)
+mvn verify -Psmoke
+
+# Regression suite (full coverage, includes smoke)
+mvn verify -Pregression
+
 # Specific browser
 BROWSER=chrome mvn verify
 ```
+
+Smoke and regression suites each write their Allure results to a dedicated subfolder (`target/allure-results/smoke` / `target/allure-results/regression`), so results from one suite never overwrite or mix with another. Run `mvn allure:serve` with the matching profile (e.g. `mvn allure:serve -Psmoke`) to inspect that suite's results.
 
 ## Logging
 
@@ -108,10 +119,10 @@ This project is licensed under the MIT License — see [LICENSE](LICENSE) for de
 - [x] GitHub Actions workflow
 - [x] AI code reviews on pull requests
 - [x] Allure test reporting
-- [ ] REST Assured + WireMock API testing
-- [ ] CartPage and cart tests
-- [ ] CheckoutPage and end-to-end checkout tests
-- [ ] Test grouping for smoke and regression suites
+- [x] REST Assured + WireMock API testing
+- [x] CartPage and cart tests
+- [x] CheckoutPage and end-to-end checkout tests
+- [x] Test grouping for smoke and regression suites
 - [ ] Environment switching
 - [ ] Cross-browser test matrix
 - [ ] Docker + Selenium Grid

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <allure.version>2.34.0</allure.version>
+    <suiteXmlFile>testng.xml</suiteXmlFile>
+    <allure.results.directory>allure-results</allure.results.directory>
   </properties>
   <dependencies>
     <dependency>
@@ -119,8 +121,11 @@
         <version>3.2.5</version>
         <configuration>
           <suiteXmlFiles>
-            <suiteXmlFile>testng.xml</suiteXmlFile>
+            <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
           </suiteXmlFiles>
+          <systemPropertyVariables>
+            <allure.results.directory>${project.build.directory}/${allure.results.directory}</allure.results.directory>
+          </systemPropertyVariables>
         </configuration>
         <dependencies>
           <dependency>
@@ -182,4 +187,20 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>smoke</id>
+      <properties>
+        <suiteXmlFile>testng-smoke.xml</suiteXmlFile>
+        <allure.results.directory>allure-results/smoke</allure.results.directory>
+      </properties>
+    </profile>
+    <profile>
+      <id>regression</id>
+      <properties>
+        <suiteXmlFile>testng-regression.xml</suiteXmlFile>
+        <allure.results.directory>allure-results/regression</allure.results.directory>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/src/test/java/com/automation/api/BookingApiIT.java
+++ b/src/test/java/com/automation/api/BookingApiIT.java
@@ -17,7 +17,7 @@ public class BookingApiIT extends BaseLiveApiTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(BookingApiIT.class);
 
-  @Test
+  @Test(groups = "smoke")
   public void shouldReturnTokenForValidCredentials() {
     LOG.info("Requesting token with valid credentials");
     RestAssured.given()
@@ -35,7 +35,7 @@ public class BookingApiIT extends BaseLiveApiTest {
         .body("token", is(notNullValue()));
   }
 
-  @Test
+  @Test(groups = "regression")
   public void shouldReturnBookingId() {
     LOG.info("Creating booking");
     RestAssured.given()
@@ -49,7 +49,7 @@ public class BookingApiIT extends BaseLiveApiTest {
         .body("booking.firstname", equalTo("Jim"));
   }
 
-  @Test
+  @Test(groups = "regression")
   public void shouldReturnBookingDetails() {
     int id = createBooking();
     LOG.info("Getting booking details from booking id: {}", id);
@@ -68,7 +68,7 @@ public class BookingApiIT extends BaseLiveApiTest {
         .body("additionalneeds", equalTo("Breakfast"));
   }
 
-  @Test
+  @Test(groups = "regression")
   public void shouldUpdateBookingDetails() {
     int id = createBooking();
     String token = getAuthToken();
@@ -85,7 +85,7 @@ public class BookingApiIT extends BaseLiveApiTest {
         .body("additionalneeds", equalTo("No Breakfast"));
   }
 
-  @Test
+  @Test(groups = "regression")
   public void shouldReturn404WhenCheckingDeletedBooking() {
     int id = createBooking();
     String token = getAuthToken();
@@ -107,7 +107,7 @@ public class BookingApiIT extends BaseLiveApiTest {
         .statusCode(404);
   }
 
-  @Test
+  @Test(groups = "regression")
   public void shouldReturnValidSchemaForCreateBooking() {
     LOG.info("Checking create booking matches schema");
     RestAssured.given()

--- a/src/test/java/com/automation/base/BaseLiveApiTest.java
+++ b/src/test/java/com/automation/base/BaseLiveApiTest.java
@@ -30,8 +30,9 @@ public class BaseLiveApiTest {
    * restful-booker requires an explicit content type. Adds request and response logging filters
    * when LOG_LEVEL is set to DEBUG.
    */
-  @BeforeClass
+  @BeforeClass(alwaysRun = true)
   public void setup() {
+    LOG.info("setUp() invoked");
     LOG.info("Creating RequestSpecification");
     spec =
         RequestSpecificationFactory.buildRequestSpec(configReader.get("BASE_API_URI"))

--- a/src/test/java/com/automation/base/BaseTest.java
+++ b/src/test/java/com/automation/base/BaseTest.java
@@ -34,8 +34,9 @@ public class BaseTest {
   }
 
   /** Sets up driver before test */
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUp() {
+    LOG.info("setUp() invoked");
     String configuredBrowser = configReader.get("BROWSER");
     String browser = configuredBrowser == null ? "firefox" : configuredBrowser.toLowerCase();
     boolean headless = "true".equalsIgnoreCase(configReader.get("HEADLESS"));

--- a/src/test/java/com/automation/runners/CucumberRegressionRunnerIT.java
+++ b/src/test/java/com/automation/runners/CucumberRegressionRunnerIT.java
@@ -1,0 +1,26 @@
+package com.automation.runners;
+
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import io.cucumber.testng.CucumberOptions;
+import org.testng.annotations.DataProvider;
+
+/** Cucumber TestNG runner for all regression tests. */
+@CucumberOptions(
+    features = "src/test/resources/features",
+    glue = "com.automation.stepdefinitions",
+    tags = "@smoke or @regression",
+    plugin = {
+      "pretty",
+      "html:target/cucumber-regression-reports.html",
+      "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm"
+    },
+    monochrome = true)
+public class CucumberRegressionRunnerIT extends AbstractTestNGCucumberTests {
+
+  /** Provides Cucumber scenarios as a TestNG DataProvider with parallel execution enabled. */
+  @Override
+  @DataProvider(parallel = true)
+  public Object[][] scenarios() {
+    return super.scenarios();
+  }
+}

--- a/src/test/java/com/automation/runners/CucumberSmokeRunnerIT.java
+++ b/src/test/java/com/automation/runners/CucumberSmokeRunnerIT.java
@@ -1,0 +1,26 @@
+package com.automation.runners;
+
+import io.cucumber.testng.AbstractTestNGCucumberTests;
+import io.cucumber.testng.CucumberOptions;
+import org.testng.annotations.DataProvider;
+
+/** Cucumber TestNG runner for all smoke tests. */
+@CucumberOptions(
+    features = "src/test/resources/features",
+    glue = "com.automation.stepdefinitions",
+    tags = "@smoke",
+    plugin = {
+      "pretty",
+      "html:target/cucumber-smoke-reports.html",
+      "io.qameta.allure.cucumber7jvm.AllureCucumber7Jvm"
+    },
+    monochrome = true)
+public class CucumberSmokeRunnerIT extends AbstractTestNGCucumberTests {
+
+  /** Provides Cucumber scenarios as a TestNG DataProvider with parallel execution enabled. */
+  @Override
+  @DataProvider(parallel = true)
+  public Object[][] scenarios() {
+    return super.scenarios();
+  }
+}

--- a/src/test/java/com/automation/tests/InventoryIT.java
+++ b/src/test/java/com/automation/tests/InventoryIT.java
@@ -17,7 +17,7 @@ public class InventoryIT extends BaseTest {
   private static final ThreadLocal<InventoryPage> inventoryPage = new ThreadLocal<>();
   private static final String ADD_TO_CART_PRODUCT = "Sauce Labs Backpack";
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void loginToSauceDemoSite() {
     getDriver().get(getConfigReader().get("BASE_URL"));
     LoginPage loginPage = new LoginPage(getDriver());
@@ -27,18 +27,18 @@ public class InventoryIT extends BaseTest {
     inventoryPage.set(new InventoryPage(getDriver()));
   }
 
-  @Test
+  @Test(groups = "smoke")
   public void aProductIsDisplayed() {
     assertThat(inventoryPage.get().getProductCount()).isNotZero();
   }
 
-  @Test
+  @Test(groups = "regression")
   public void theCartBadgeDisplaysTheNumberOfItemsInIt() {
     inventoryPage.get().clickAddToCart(ADD_TO_CART_PRODUCT);
     assertThat(inventoryPage.get().getCartBadgeNumber()).isEqualTo(1);
   }
 
-  @Test(dataProvider = "sortOptionsData")
+  @Test(groups = "regression", dataProvider = "sortOptionsData")
   public void sortInventoryTest(InventoryScenario inventoryScenario) {
     inventoryPage.get().selectSortOption(inventoryScenario.sortOption());
     assertThat(inventoryPage.get().getFirstItemName()).isEqualTo(inventoryScenario.firstItem());

--- a/src/test/java/com/automation/tests/LoginIT.java
+++ b/src/test/java/com/automation/tests/LoginIT.java
@@ -15,13 +15,13 @@ public class LoginIT extends BaseTest {
 
   private static final ThreadLocal<LoginPage> loginPage = new ThreadLocal<>();
 
-  @BeforeMethod
+  @BeforeMethod(alwaysRun = true)
   public void setUpPage() {
     getDriver().get(getConfigReader().get("BASE_URL"));
     loginPage.set(new LoginPage(getDriver()));
   }
 
-  @Test
+  @Test(groups = "smoke")
   public void successfulLoginTest() {
     loginPage
         .get()
@@ -31,7 +31,7 @@ public class LoginIT extends BaseTest {
         .waitForUrl(getConfigReader().get("BASE_URL") + getConfigReader().get("INVENTORY_PATH"));
   }
 
-  @Test(dataProvider = "failedLoginData")
+  @Test(groups = "regression", dataProvider = "failedLoginData")
   public void failedLoginTest(LoginScenario scenario) {
     loginPage.get().login(scenario.username(), scenario.password());
     assertThat(loginPage.get().getErrorMessage()).contains(scenario.expectedError());

--- a/src/test/resources/features/cart.feature
+++ b/src/test/resources/features/cart.feature
@@ -1,11 +1,13 @@
 Feature: Cart Page interactions
 
+    @regression
     Scenario: Add item to cart
         Given the user is logged in
         When the add to cart button is clicked for 'Sauce Labs Backpack'
         And the cart icon is clicked
         Then the item should be displayed on the cart page
 
+    @regression
     Scenario: Remove item from cart
         Given the user is logged in
         When the add to cart button is clicked for 'Sauce Labs Backpack'
@@ -13,6 +15,7 @@ Feature: Cart Page interactions
         And the remove button is clicked
         Then the item should be removed from the cart page
 
+    @regression
     Scenario: Verify item count
         Given the user is logged in
         When the add to cart button is clicked for 'Sauce Labs Backpack'

--- a/src/test/resources/features/checkout.feature
+++ b/src/test/resources/features/checkout.feature
@@ -1,5 +1,6 @@
 Feature: Checkout Page Interactions
 
+    @smoke
     Scenario: Successful order journey
         Given the user is logged in
         When the product name and price are stored
@@ -12,6 +13,7 @@ Feature: Checkout Page Interactions
         And the finish button is clicked
         Then they should be presented with the order complete message
 
+    @regression
     Scenario: Missing shipping information
         Given the user is logged in
         When the add to cart button is clicked for 'Sauce Labs Backpack'

--- a/src/test/resources/features/inventory.feature
+++ b/src/test/resources/features/inventory.feature
@@ -1,9 +1,11 @@
 Feature: Inventory page interactions
 
+    @smoke
     Scenario: Product is displayed
         Given the user is logged in
         Then a product is displayed
 
+    @regression
     Scenario Outline: Sorting products
         Given the user is logged in
         When the filter is changed to '<sort_option>'
@@ -16,6 +18,7 @@ Feature: Inventory page interactions
             | Price (low to high) | Sauce Labs Onesie                 | Sauce Labs Fleece Jacket          |
             | Price (high to low) | Sauce Labs Fleece Jacket          | Sauce Labs Onesie                 |
 
+    @regression
     Scenario: Cart badge is updated
         Given the user is logged in
         When the add to cart button is clicked for 'Sauce Labs Backpack'

--- a/src/test/resources/features/login.feature
+++ b/src/test/resources/features/login.feature
@@ -1,25 +1,30 @@
 Feature: User Login
 
+    @smoke
     Scenario: Successful login
         Given the user is on the login page
         When they login with valid credentials
         Then they should be redirected to the inventory page
 
+    @regression
     Scenario: Failed login
         Given the user is on the login page
         When they login with locked out credentials
         Then they should see a locked out error message
 
+    @regression
     Scenario: Invalid password
         Given the user is on the login page
         When they login with invalid credentials
         Then they should see an invalid credentials error message
 
+    @regression
     Scenario: Logout
         Given the user is logged in
         When the logout sidebar link is clicked
         Then they should be on the login page
 
+    @regression
     Scenario: Direct URL access
         Given the user is on the login page
         When they navigate to the inventory URL

--- a/src/test/resources/features/productdetails.feature
+++ b/src/test/resources/features/productdetails.feature
@@ -1,17 +1,20 @@
 Feature: Product Details page interactions
 
+    @regression
     Scenario: Clicking product navigates to detail page
         Given the user is logged in
         When the product name and price are stored
         And a product is clicked
         Then they are on the details page for the clicked product
 
+    @regression
     Scenario: Product name and price match between inventory and detail pages
         Given the user is logged in
         When the product name and price are stored
         And a product is clicked
         Then the product name and price match on details page
 
+    @regression
     Scenario: The back button returns to the inventory page
         Given the user is logged in
         When a product is clicked

--- a/testng-regression.xml
+++ b/testng-regression.xml
@@ -1,0 +1,44 @@
+<!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
+<suite name="AutomationRegressionSuite" parallel="methods" thread-count="3" data-provider-thread-count="3">
+
+    <test name="LoginTests">
+        <groups>
+            <run>
+                <include name="smoke"/>
+                <include name="regression"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="com.automation.tests.LoginIT"/>
+        </classes>
+    </test>
+    <test name="InventoryTests">
+        <groups>
+            <run>
+                <include name="smoke"/>
+                <include name="regression"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="com.automation.tests.InventoryIT"/>
+        </classes>
+    </test>
+    <test name="BookingApiTests">
+        <groups>
+            <run>
+                <include name="smoke"/>
+                <include name="regression"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="com.automation.api.BookingApiIT"/>
+        </classes>
+    </test>
+
+    <test name="CucumberTests">
+        <classes>
+            <class name="com.automation.runners.CucumberRegressionRunnerIT"/>
+        </classes>
+    </test>
+
+</suite>

--- a/testng-smoke.xml
+++ b/testng-smoke.xml
@@ -1,17 +1,32 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd">
-<suite name="AutomationSuite" parallel="methods" thread-count="3" data-provider-thread-count="3">
+<suite name="AutomationSmokeSuite" parallel="methods" thread-count="3" data-provider-thread-count="3">
 
     <test name="LoginTests">
+        <groups>
+            <run>
+                <include name="smoke"/>
+            </run>
+        </groups>
         <classes>
             <class name="com.automation.tests.LoginIT"/>
         </classes>
     </test>
     <test name="InventoryTests">
+        <groups>
+            <run>
+                <include name="smoke"/>
+            </run>
+        </groups>
         <classes>
             <class name="com.automation.tests.InventoryIT"/>
         </classes>
     </test>
     <test name="BookingApiTests">
+        <groups>
+            <run>
+                <include name="smoke"/>
+            </run>
+        </groups>
         <classes>
             <class name="com.automation.api.BookingApiIT"/>
         </classes>
@@ -19,7 +34,7 @@
 
     <test name="CucumberTests">
         <classes>
-            <class name="com.automation.runners.CucumberRunnerIT"/>
+            <class name="com.automation.runners.CucumberSmokeRunnerIT"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Summary
Adds smoke and regression test groupings so a fast, critical-path
subset can be run independently of the full suite, via Maven
profiles (`-Psmoke` / `-Pregression`).

## Changes
- TestNG `@Test` methods tagged with `groups = "smoke"` /
  `"regression"` across LoginIT, InventoryIT, BookingApiIT
- Cucumber scenarios tagged `@smoke` / `@regression` across all
  feature files, with two new runner classes
  (CucumberSmokeRunnerIT, CucumberRegressionRunnerIT) filtering via
  tag expressions
- New `testng-smoke.xml` / `testng-regression.xml` suite files
- New `smoke` / `regression` Maven profiles selecting the suite
  file and an isolated Allure results directory per suite
- Fixed a pre-existing issue where `@BeforeMethod`/`@BeforeClass`
  configuration methods were silently skipped under TestNG group
  filtering, by adding `alwaysRun = true` where needed
- README updated with new run commands and project structure

## Testing
- `mvn verify -Psmoke` — 6/6 tests pass (3 TestNG smoke, 3 Cucumber
  smoke scenarios)
- `mvn verify -Pregression` — 34/34 tests pass (full suite,
  regression includes smoke)
- `mvn verify` (no profile) — 34/34 tests pass, confirms default
  behaviour unchanged
- Verified Allure reports generate correctly and land in
  suite-specific subfolders for both profiles

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated smoke and regression test suites, including parallel execution.
  * Added Cucumber runners for smoke and regression scenarios.
  * Tests are now categorised for targeted suite execution.
  * Allure results are separated by suite to prevent reports from mixing.

* **Documentation**
  * Updated project documentation with suite commands, configuration details, and reporting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->